### PR TITLE
feat(#30): implement Terraform network + database modules

### DIFF
--- a/fluxion-backend/infra/main.tf
+++ b/fluxion-backend/infra/main.tf
@@ -34,8 +34,11 @@ module "network" {
 }
 
 module "database" {
-  source      = "./modules/database"
-  environment = var.environment
+  source             = "./modules/database"
+  environment        = var.environment
+  private_subnet_ids = module.network.private_subnet_ids
+  rds_sg_id          = module.network.rds_sg_id
+  db_password        = var.db_password
 }
 
 module "auth" {

--- a/fluxion-backend/infra/modules/database/main.tf
+++ b/fluxion-backend/infra/modules/database/main.tf
@@ -1,2 +1,110 @@
-# RDS PostgreSQL 16 (db.t3.micro)
-# Implementation: issue #30
+# RDS PostgreSQL 16, RDS Proxy, Secrets Manager for Fluxion backend
+
+# --- DB Subnet Group ---
+
+resource "aws_db_subnet_group" "main" {
+  name       = "fluxion-db-subnet-group"
+  subnet_ids = var.private_subnet_ids
+
+  tags = { Name = "fluxion-db-subnet-group" }
+}
+
+# --- RDS Instance ---
+
+resource "aws_db_instance" "main" {
+  identifier     = "fluxion-db"
+  engine         = "postgres"
+  engine_version = "16"
+  instance_class = "db.t3.micro"
+
+  db_name  = "fluxion"
+  username = "fluxion_admin"
+  password = var.db_password
+
+  allocated_storage     = 20
+  max_allocated_storage = 50
+  storage_type          = "gp3"
+
+  db_subnet_group_name   = aws_db_subnet_group.main.name
+  vpc_security_group_ids = [var.rds_sg_id]
+
+  multi_az            = false
+  publicly_accessible = false
+  skip_final_snapshot = true
+
+  backup_retention_period = 7
+
+  tags = { Name = "fluxion-db" }
+}
+
+# --- Secrets Manager (for RDS Proxy auth) ---
+
+resource "aws_secretsmanager_secret" "db_credentials" {
+  name = "fluxion-db-credentials"
+}
+
+resource "aws_secretsmanager_secret_version" "db_credentials" {
+  secret_id = aws_secretsmanager_secret.db_credentials.id
+  secret_string = jsonencode({
+    username = aws_db_instance.main.username
+    password = var.db_password
+  })
+}
+
+# --- IAM Role for RDS Proxy ---
+
+resource "aws_iam_role" "rds_proxy" {
+  name = "fluxion-rds-proxy-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = { Service = "rds.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "rds_proxy_secrets" {
+  role = aws_iam_role.rds_proxy.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["secretsmanager:GetSecretValue"]
+      Resource = [aws_secretsmanager_secret.db_credentials.arn]
+    }]
+  })
+}
+
+# --- RDS Proxy ---
+
+resource "aws_db_proxy" "main" {
+  name                   = "fluxion-db-proxy"
+  engine_family          = "POSTGRESQL"
+  role_arn               = aws_iam_role.rds_proxy.arn
+  vpc_subnet_ids         = var.private_subnet_ids
+  vpc_security_group_ids = [var.rds_sg_id]
+
+  auth {
+    auth_scheme = "SECRETS"
+    iam_auth    = "DISABLED"
+    secret_arn  = aws_secretsmanager_secret.db_credentials.arn
+  }
+}
+
+resource "aws_db_proxy_default_target_group" "main" {
+  db_proxy_name = aws_db_proxy.main.name
+
+  connection_pool_config {
+    max_connections_percent = 100
+  }
+}
+
+resource "aws_db_proxy_target" "main" {
+  db_proxy_name          = aws_db_proxy.main.name
+  target_group_name      = aws_db_proxy_default_target_group.main.name
+  db_instance_identifier = aws_db_instance.main.identifier
+}

--- a/fluxion-backend/infra/modules/database/outputs.tf
+++ b/fluxion-backend/infra/modules/database/outputs.tf
@@ -1,2 +1,19 @@
-# RDS endpoint, database name
-# Implementation: issue #30
+output "rds_endpoint" {
+  value = aws_db_instance.main.endpoint
+}
+
+output "rds_proxy_endpoint" {
+  value = aws_db_proxy.main.endpoint
+}
+
+output "db_name" {
+  value = aws_db_instance.main.db_name
+}
+
+output "db_username" {
+  value = aws_db_instance.main.username
+}
+
+output "db_secret_arn" {
+  value = aws_secretsmanager_secret.db_credentials.arn
+}

--- a/fluxion-backend/infra/modules/database/variables.tf
+++ b/fluxion-backend/infra/modules/database/variables.tf
@@ -2,3 +2,18 @@ variable "environment" {
   type    = string
   default = "dev"
 }
+
+variable "private_subnet_ids" {
+  type        = list(string)
+  description = "Private subnet IDs for RDS and RDS Proxy"
+}
+
+variable "rds_sg_id" {
+  type        = string
+  description = "Security group ID for RDS instance"
+}
+
+variable "db_password" {
+  type      = string
+  sensitive = true
+}

--- a/fluxion-backend/infra/modules/network/main.tf
+++ b/fluxion-backend/infra/modules/network/main.tf
@@ -1,2 +1,139 @@
-# VPC, subnets, security groups for Fluxion backend
-# Implementation: issue #30
+# VPC, subnets, NAT Gateway, security groups for Fluxion backend
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+locals {
+  azs = slice(data.aws_availability_zones.available.names, 0, 2)
+}
+
+# --- VPC ---
+
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = { Name = "fluxion-vpc" }
+}
+
+# --- Subnets ---
+
+resource "aws_subnet" "public" {
+  count = 2
+
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = cidrsubnet(var.vpc_cidr, 8, count.index + 1)
+  availability_zone       = local.azs[count.index]
+  map_public_ip_on_launch = true
+
+  tags = { Name = "fluxion-public-${local.azs[count.index]}" }
+}
+
+resource "aws_subnet" "private" {
+  count = 2
+
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = cidrsubnet(var.vpc_cidr, 8, count.index + 10)
+  availability_zone = local.azs[count.index]
+
+  tags = { Name = "fluxion-private-${local.azs[count.index]}" }
+}
+
+# --- Internet Gateway ---
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = { Name = "fluxion-igw" }
+}
+
+# --- NAT Gateway ---
+
+resource "aws_eip" "nat" {
+  domain = "vpc"
+
+  tags = { Name = "fluxion-nat-eip" }
+}
+
+resource "aws_nat_gateway" "main" {
+  allocation_id = aws_eip.nat.id
+  subnet_id     = aws_subnet.public[0].id
+
+  tags = { Name = "fluxion-nat-gw" }
+
+  depends_on = [aws_internet_gateway.main]
+}
+
+# --- Route Tables ---
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = { Name = "fluxion-public-rt" }
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.main.id
+  }
+
+  tags = { Name = "fluxion-private-rt" }
+}
+
+resource "aws_route_table_association" "public" {
+  count = 2
+
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table_association" "private" {
+  count = 2
+
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private.id
+}
+
+# --- Security Groups ---
+
+resource "aws_security_group" "lambda" {
+  name_prefix = "fluxion-lambda-"
+  description = "Security group for Fluxion Lambda functions"
+  vpc_id      = aws_vpc.main.id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "All outbound traffic"
+  }
+
+  tags = { Name = "fluxion-lambda-sg" }
+}
+
+resource "aws_security_group" "rds" {
+  name_prefix = "fluxion-rds-"
+  description = "Security group for Fluxion RDS instance"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [aws_security_group.lambda.id]
+    description     = "PostgreSQL from Lambda"
+  }
+
+  tags = { Name = "fluxion-rds-sg" }
+}

--- a/fluxion-backend/infra/modules/network/outputs.tf
+++ b/fluxion-backend/infra/modules/network/outputs.tf
@@ -1,2 +1,19 @@
-# VPC ID, subnet IDs, security group IDs
-# Implementation: issue #30
+output "vpc_id" {
+  value = aws_vpc.main.id
+}
+
+output "private_subnet_ids" {
+  value = aws_subnet.private[*].id
+}
+
+output "public_subnet_ids" {
+  value = aws_subnet.public[*].id
+}
+
+output "lambda_sg_id" {
+  value = aws_security_group.lambda.id
+}
+
+output "rds_sg_id" {
+  value = aws_security_group.rds.id
+}

--- a/fluxion-backend/infra/modules/network/variables.tf
+++ b/fluxion-backend/infra/modules/network/variables.tf
@@ -2,3 +2,8 @@ variable "environment" {
   type    = string
   default = "dev"
 }
+
+variable "vpc_cidr" {
+  type    = string
+  default = "10.0.0.0/16"
+}

--- a/fluxion-backend/infra/outputs.tf
+++ b/fluxion-backend/infra/outputs.tf
@@ -1,2 +1,21 @@
-# Outputs consumed by OEM and Frontend via terraform_remote_state
-# Implementation: issues #30, #32, #33
+# Outputs consumed by OEM and Frontend via terraform_remote_state or SSM
+
+output "vpc_id" {
+  value = module.network.vpc_id
+}
+
+output "private_subnet_ids" {
+  value = module.network.private_subnet_ids
+}
+
+output "lambda_sg_id" {
+  value = module.network.lambda_sg_id
+}
+
+output "rds_endpoint" {
+  value = module.database.rds_endpoint
+}
+
+output "rds_proxy_endpoint" {
+  value = module.database.rds_proxy_endpoint
+}

--- a/fluxion-backend/infra/ssm.tf
+++ b/fluxion-backend/infra/ssm.tf
@@ -1,0 +1,31 @@
+# SSM parameters for cross-service import (OEM, Frontend)
+
+resource "aws_ssm_parameter" "vpc_id" {
+  name  = "/fluxion/network/vpc_id"
+  type  = "String"
+  value = module.network.vpc_id
+}
+
+resource "aws_ssm_parameter" "private_subnet_ids" {
+  name  = "/fluxion/network/private_subnet_ids"
+  type  = "StringList"
+  value = join(",", module.network.private_subnet_ids)
+}
+
+resource "aws_ssm_parameter" "lambda_sg_id" {
+  name  = "/fluxion/network/lambda_sg_id"
+  type  = "String"
+  value = module.network.lambda_sg_id
+}
+
+resource "aws_ssm_parameter" "rds_proxy_endpoint" {
+  name  = "/fluxion/database/rds_proxy_endpoint"
+  type  = "String"
+  value = module.database.rds_proxy_endpoint
+}
+
+resource "aws_ssm_parameter" "db_secret_arn" {
+  name  = "/fluxion/database/db_secret_arn"
+  type  = "String"
+  value = module.database.db_secret_arn
+}

--- a/fluxion-backend/infra/terraform.tfvars.example
+++ b/fluxion-backend/infra/terraform.tfvars.example
@@ -1,2 +1,3 @@
 region      = "ap-southeast-1"
 environment = "dev"
+db_password = "CHANGE_ME"

--- a/fluxion-backend/infra/variables.tf
+++ b/fluxion-backend/infra/variables.tf
@@ -7,3 +7,8 @@ variable "environment" {
   type    = string
   default = "dev"
 }
+
+variable "db_password" {
+  type      = string
+  sensitive = true
+}


### PR DESCRIPTION
## Summary

- Implement `modules/network/`: VPC (10.0.0.0/16), 2 public + 2 private subnets (2 AZs), IGW, NAT GW, Lambda + RDS security groups
- Implement `modules/database/`: RDS PostgreSQL 16 (db.t3.micro), RDS Proxy, Secrets Manager, IAM role
- Wire module dependencies in root `main.tf`, add SSM parameter exports for cross-service import

## Commits (1 per phase)

| Phase | Scope |
|-------|-------|
| 1 | Network module — VPC, subnets, IGW, NAT GW, security groups |
| 2 | Database module — RDS, RDS Proxy, Secrets Manager, IAM |
| 3 | Root wiring, SSM exports, validation |

## Test plan

- [x] `terraform validate` passes for network module (isolated)
- [x] `terraform validate` passes for database module (isolated)
- [x] `terraform validate` passes for full root config (wired)
- [ ] `terraform plan` with AWS credentials (manual)
- [ ] `terraform apply` provisions VPC + RDS (manual)