### PR TITLE
feat(#31): database migration — multi-tenant stored procedures

### DIFF
--- a/fluxion-backend/alembic/script.py.mako
+++ b/fluxion-backend/alembic/script.py.mako
@@ -1,0 +1,26 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/fluxion-backend/alembic/versions/2bc76b6f39ea_create_seed_tenant_data_procedure.py
+++ b/fluxion-backend/alembic/versions/2bc76b6f39ea_create_seed_tenant_data_procedure.py
@@ -5,17 +5,15 @@ Revises: 7400fe8d7a01
 Create Date: 2026-04-03 15:13:57.647557
 
 """
-from typing import Sequence, Union
+from collections.abc import Sequence
 
 from alembic import op
-import sqlalchemy as sa
-
 
 # revision identifiers, used by Alembic.
 revision: str = '2bc76b6f39ea'
-down_revision: Union[str, None] = '7400fe8d7a01'
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = '7400fe8d7a01'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/fluxion-backend/alembic/versions/2bc76b6f39ea_create_seed_tenant_data_procedure.py
+++ b/fluxion-backend/alembic/versions/2bc76b6f39ea_create_seed_tenant_data_procedure.py
@@ -1,0 +1,77 @@
+"""create seed tenant data procedure
+
+Revision ID: 2bc76b6f39ea
+Revises: 7400fe8d7a01
+Create Date: 2026-04-03 15:13:57.647557
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '2bc76b6f39ea'
+down_revision: Union[str, None] = '7400fe8d7a01'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("""
+    CREATE OR REPLACE FUNCTION seed_tenant_data(schema_name TEXT) RETURNS VOID AS $$
+    BEGIN
+        -- Services
+        EXECUTE format('
+            INSERT INTO %I.services (id, name, is_enabled) VALUES
+                (1, ''Inventory'', TRUE),
+                (2, ''Supply Chain'', FALSE),
+                (3, ''Postpaid'', TRUE)
+        ', schema_name);
+
+        -- States
+        EXECUTE format('
+            INSERT INTO %I.states (id, name) VALUES
+                (1, ''Idle''),
+                (2, ''Registered''),
+                (3, ''Enrolled''),
+                (4, ''Active''),
+                (5, ''Locked''),
+                (6, ''Released'')
+        ', schema_name);
+
+        -- Policies (each policy -> 1 state)
+        EXECUTE format('
+            INSERT INTO %I.policies (id, name, state_id, service_type_id) VALUES
+                (1, ''Idle'', 1, 1),
+                (2, ''Registered'', 2, 3),
+                (3, ''Enrolled'', 3, 3),
+                (4, ''Active'', 4, 3),
+                (5, ''Locked'', 5, 3),
+                (6, ''Released'', 6, 3)
+        ', schema_name);
+
+        -- Actions (transitions: from_state_id -> apply_policy_id)
+        EXECUTE format('
+            INSERT INTO %I.actions (name, action_type_id, from_state_id, apply_policy_id, service_type_id) VALUES
+                (''Upload'', 1, NULL, 1, NULL),
+                (''Register'', 2, 1, 2, 1),
+                (''Checkin'', 3, 2, 3, 3),
+                (''Activate'', 4, 3, 4, 3),
+                (''Lock'', 5, 4, 5, 3),
+                (''Unlock'', 6, 5, 4, 3),
+                (''Send Message'', 7, 4, 4, 3),
+                (''Lock Message'', 8, 5, 5, 3),
+                (''Release'', 9, 4, 6, 3),
+                (''Release'', 9, 5, 6, 3),
+                (''Deregister'', 10, 4, 1, 3),
+                (''Deregister'', 10, 5, 1, 3)
+        ', schema_name);
+    END;
+    $$ LANGUAGE plpgsql;
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP FUNCTION IF EXISTS seed_tenant_data(TEXT);")

--- a/fluxion-backend/alembic/versions/7400fe8d7a01_create_tenant_tables_procedure.py
+++ b/fluxion-backend/alembic/versions/7400fe8d7a01_create_tenant_tables_procedure.py
@@ -1,21 +1,19 @@
 """create tenant tables procedure
 
 Revision ID: 7400fe8d7a01
-Revises: 
+Revises:
 Create Date: 2026-04-03 15:13:01.802260
 
 """
-from typing import Sequence, Union
+from collections.abc import Sequence
 
 from alembic import op
-import sqlalchemy as sa
-
 
 # revision identifiers, used by Alembic.
 revision: str = '7400fe8d7a01'
-down_revision: Union[str, None] = None
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/fluxion-backend/alembic/versions/7400fe8d7a01_create_tenant_tables_procedure.py
+++ b/fluxion-backend/alembic/versions/7400fe8d7a01_create_tenant_tables_procedure.py
@@ -1,0 +1,181 @@
+"""create tenant tables procedure
+
+Revision ID: 7400fe8d7a01
+Revises: 
+Create Date: 2026-04-03 15:13:01.802260
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '7400fe8d7a01'
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("""
+    CREATE OR REPLACE FUNCTION create_tenant_tables(schema_name TEXT) RETURNS VOID AS $$
+    BEGIN
+        -- Create schema
+        EXECUTE format('CREATE SCHEMA IF NOT EXISTS %I', schema_name);
+
+        -- FSM Config Tables
+        EXECUTE format('
+            CREATE TABLE %I.services (
+                id SMALLINT PRIMARY KEY,
+                name VARCHAR(50) UNIQUE NOT NULL,
+                is_enabled BOOL,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )', schema_name);
+
+        EXECUTE format('
+            CREATE TABLE %I.states (
+                id SMALLINT PRIMARY KEY,
+                name VARCHAR(50) UNIQUE NOT NULL,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )', schema_name);
+
+        EXECUTE format('
+            CREATE TABLE %I.policies (
+                id SMALLINT PRIMARY KEY,
+                name VARCHAR(100) NOT NULL,
+                service_type_id SMALLINT REFERENCES %I.services(id),
+                state_id SMALLINT REFERENCES %I.states(id),
+                color VARCHAR(6),
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )', schema_name, schema_name, schema_name);
+
+        EXECUTE format('
+            CREATE TABLE %I.actions (
+                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                name VARCHAR(100) NOT NULL,
+                action_type_id SMALLINT NOT NULL,
+                from_state_id SMALLINT REFERENCES %I.states(id),
+                service_type_id SMALLINT REFERENCES %I.services(id),
+                apply_policy_id SMALLINT REFERENCES %I.policies(id),
+                configuration JSONB,
+                ext_fields JSONB,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )', schema_name, schema_name, schema_name, schema_name);
+
+        -- Core Device Tables
+        EXECUTE format('
+            CREATE TABLE %I.devices (
+                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                state_id SMALLINT NOT NULL REFERENCES %I.states(id) DEFAULT 1,
+                current_policy_id SMALLINT REFERENCES %I.policies(id),
+                assigned_action_id UUID REFERENCES %I.actions(id),
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )', schema_name, schema_name, schema_name, schema_name);
+
+        EXECUTE format('
+            CREATE TABLE %I.device_informations (
+                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                device_id UUID NOT NULL UNIQUE REFERENCES %I.devices(id) ON DELETE CASCADE,
+                serial_number VARCHAR(50) UNIQUE NOT NULL,
+                udid VARCHAR(50) UNIQUE NOT NULL,
+                name VARCHAR(200),
+                model VARCHAR(100),
+                os_version VARCHAR(20),
+                battery_level REAL,
+                wifi_mac VARCHAR(20),
+                is_supervised BOOLEAN DEFAULT FALSE,
+                last_checkin_at TIMESTAMPTZ,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                ext_fields JSONB
+            )', schema_name, schema_name);
+
+        EXECUTE format('
+            CREATE TABLE %I.device_tokens (
+                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                device_id UUID NOT NULL UNIQUE REFERENCES %I.devices(id) ON DELETE CASCADE,
+                push_token BYTEA NOT NULL,
+                push_magic VARCHAR(200) NOT NULL,
+                unlock_token BYTEA,
+                topic VARCHAR(200) NOT NULL,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )', schema_name, schema_name);
+
+        -- Transaction Tables
+        EXECUTE format('
+            CREATE TABLE %I.action_executions (
+                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                device_id UUID NOT NULL REFERENCES %I.devices(id),
+                action_id UUID NOT NULL REFERENCES %I.actions(id),
+                command_uuid UUID NOT NULL UNIQUE DEFAULT gen_random_uuid(),
+                status VARCHAR(20) NOT NULL DEFAULT ''ACTION_PENDING'',
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                ext_fields JSONB
+            )', schema_name, schema_name, schema_name);
+
+        EXECUTE format('
+            CREATE TABLE %I.milestones (
+                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                device_id UUID NOT NULL REFERENCES %I.devices(id),
+                assigned_action_id UUID REFERENCES %I.actions(id),
+                policy_id SMALLINT REFERENCES %I.policies(id),
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                ext_fields JSONB
+            )', schema_name, schema_name, schema_name, schema_name);
+
+        -- User Tables
+        EXECUTE format('
+            CREATE TABLE %I.users (
+                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                email VARCHAR(255) UNIQUE NOT NULL,
+                name VARCHAR(200) NOT NULL,
+                role VARCHAR(20) NOT NULL DEFAULT ''operator'',
+                cognito_sub VARCHAR(100) UNIQUE NOT NULL,
+                is_active BOOLEAN NOT NULL DEFAULT TRUE,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )', schema_name);
+
+        -- Chat Tables
+        EXECUTE format('
+            CREATE TABLE %I.chat_sessions (
+                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                user_id UUID NOT NULL REFERENCES %I.users(id),
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )', schema_name, schema_name);
+
+        EXECUTE format('
+            CREATE TABLE %I.chat_messages (
+                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                session_id UUID NOT NULL REFERENCES %I.chat_sessions(id) ON DELETE CASCADE,
+                role VARCHAR(20) NOT NULL,
+                content TEXT,
+                tool_calls JSONB,
+                tool_result JSONB,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )', schema_name, schema_name);
+
+        -- Indexes
+        EXECUTE format('CREATE INDEX idx_%I_devices_state ON %I.devices(state_id)', schema_name, schema_name);
+        EXECUTE format('CREATE INDEX idx_%I_devices_policy ON %I.devices(current_policy_id)', schema_name, schema_name);
+        EXECUTE format('CREATE INDEX idx_%I_devices_assigned ON %I.devices(assigned_action_id) WHERE assigned_action_id IS NOT NULL', schema_name, schema_name);
+        EXECUTE format('CREATE INDEX idx_%I_ae_device ON %I.action_executions(device_id)', schema_name, schema_name);
+        EXECUTE format('CREATE UNIQUE INDEX idx_%I_ae_cmd ON %I.action_executions(command_uuid)', schema_name, schema_name);
+        EXECUTE format('CREATE INDEX idx_%I_ae_active ON %I.action_executions(status) WHERE status NOT IN (''ACTION_COMPLETED'', ''ACTION_FAILED'')', schema_name, schema_name);
+        EXECUTE format('CREATE INDEX idx_%I_ms_device ON %I.milestones(device_id)', schema_name, schema_name);
+        EXECUTE format('CREATE INDEX idx_%I_ms_created ON %I.milestones(created_at)', schema_name, schema_name);
+        EXECUTE format('CREATE INDEX idx_%I_cs_user ON %I.chat_sessions(user_id)', schema_name, schema_name);
+        EXECUTE format('CREATE INDEX idx_%I_cm_session ON %I.chat_messages(session_id, created_at)', schema_name, schema_name);
+    END;
+    $$ LANGUAGE plpgsql;
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP FUNCTION IF EXISTS create_tenant_tables(TEXT);")

--- a/fluxion-backend/pyproject.toml
+++ b/fluxion-backend/pyproject.toml
@@ -26,6 +26,9 @@ src = ["modules"]
 [tool.ruff.lint]
 select = ["E", "F", "I", "N", "W", "UP"]
 
+[tool.ruff.lint.per-file-ignores]
+"alembic/versions/*.py" = ["E501"]
+
 [tool.pytest.ini_options]
 testpaths = ["modules"]
 python_files = "test_*.py"

--- a/fluxion-backend/pyproject.toml
+++ b/fluxion-backend/pyproject.toml
@@ -11,6 +11,7 @@ aws-lambda-powertools = {extras = ["all"], version = "*"}
 psycopg = {extras = ["binary"], version = "*"}
 alembic = "^1.18.4"
 sqlalchemy = "^2.0.48"
+psycopg2-binary = "^2.9.11"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "*"

--- a/fluxion-backend/pyproject.toml
+++ b/fluxion-backend/pyproject.toml
@@ -9,6 +9,8 @@ packages = [{include = "modules"}]
 python = "^3.12"
 aws-lambda-powertools = {extras = ["all"], version = "*"}
 psycopg = {extras = ["binary"], version = "*"}
+alembic = "^1.18.4"
+sqlalchemy = "^2.0.48"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "*"


### PR DESCRIPTION
## Summary

- Multi-tenant architecture via PostgreSQL schema-per-tenant
- `create_tenant_tables(schema_name)` — creates schema + 12 tables + 10 indexes
- `seed_tenant_data(schema_name)` — inserts default FSM config (3 services, 6 states, 6 policies, 12 actions)
- New tenant: `SELECT create_tenant_tables('x'); SELECT seed_tenant_data('x');`

## Commits (1 per phase)

| Phase | Scope |
|-------|-------|
| 1 | create_tenant_tables stored procedure (Alembic migration) |
| 2 | seed_tenant_data stored procedure (Alembic migration) |
| 3 | Add psycopg2-binary dep, validated on local Docker PG |

## Test plan

- [x] `alembic upgrade head` creates both procedures
- [x] `create_tenant_tables('test')` creates 12 tables
- [x] `seed_tenant_data('test')` inserts 3+6+6+12 rows
- [x] 31 indexes created (10 custom + 21 PK/UNIQUE)
- [x] `DROP SCHEMA test CASCADE` cleanly removes tenant
- [x] `alembic downgrade base` drops both procedures