### PR TITLE
feat(#32): Cognito auth module + CI/CD deploy pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,135 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+
+env:
+  AWS_REGION: ap-southeast-1
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - service: fluxion-backend
+            lang: python
+          - service: fluxion-oem-processor
+            lang: python
+          - service: fluxion-frontend
+            lang: bun
+    steps:
+      - uses: actions/checkout@v4
+
+      # Python services
+      - if: matrix.lang == 'python'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - if: matrix.lang == 'python'
+        run: pip install poetry
+      - if: matrix.lang == 'python'
+        working-directory: ${{ matrix.service }}
+        run: poetry install
+      - if: matrix.lang == 'python'
+        working-directory: ${{ matrix.service }}
+        run: poetry run ruff check .
+      - if: matrix.lang == 'python'
+        working-directory: ${{ matrix.service }}
+        run: poetry run pytest
+
+      # Bun/frontend service
+      - if: matrix.lang == 'bun'
+        uses: oven-sh/setup-bun@v2
+      - if: matrix.lang == 'bun'
+        working-directory: ${{ matrix.service }}
+        run: bun install --frozen-lockfile
+      - if: matrix.lang == 'bun'
+        working-directory: ${{ matrix.service }}
+        run: bun run lint
+      - if: matrix.lang == 'bun'
+        working-directory: ${{ matrix.service }}
+        run: bun run build
+      - if: matrix.lang == 'bun'
+        working-directory: ${{ matrix.service }}
+        run: bun run test -- --run
+
+  terraform:
+    needs: lint-test
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      max-parallel: 1
+      matrix:
+        service:
+          - fluxion-backend/infra
+          - fluxion-oem-processor/infra
+          - fluxion-frontend/infra
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - working-directory: ${{ matrix.service }}
+        run: terraform init
+
+      - working-directory: ${{ matrix.service }}
+        run: terraform plan -out=tfplan
+
+      - working-directory: ${{ matrix.service }}
+        run: terraform apply -auto-approve tfplan
+
+  docker-push:
+    needs: terraform
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      matrix:
+        include:
+          - service: fluxion-backend
+            modules: >-
+              device_resolver
+              action_resolver
+              platform_resolver
+              user_resolver
+              upload_resolver
+              chat_resolver
+              action_trigger
+              upload_processor
+              checkin_handler
+          - service: fluxion-oem-processor
+            modules: apple_process_action
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - uses: aws-actions/amazon-ecr-login@v2
+        id: ecr-login
+
+      - name: Build and push Docker images
+        env:
+          ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
+        run: |
+          for module in ${{ matrix.modules }}; do
+            if [ "${{ matrix.service }}" = "fluxion-backend" ]; then
+              ctx="${{ matrix.service }}/modules/${module}"
+            else
+              ctx="${{ matrix.service }}/${module}"
+            fi
+            image="${ECR_REGISTRY}/fluxion-${module}:${GITHUB_SHA::7}"
+            docker build -t "${image}" "${ctx}"
+            docker push "${image}"
+          done

--- a/fluxion-backend/infra/modules/auth/main.tf
+++ b/fluxion-backend/infra/modules/auth/main.tf
@@ -1,2 +1,84 @@
-# Cognito User Pool + App Client
-# Implementation: issue #32
+# Cognito User Pool + App Client for Fluxion authentication
+
+resource "aws_cognito_user_pool" "main" {
+  name = "fluxion-user-pool"
+
+  # Password policy
+  password_policy {
+    minimum_length    = 8
+    require_lowercase = true
+    require_numbers   = true
+    require_symbols   = false
+    require_uppercase = true
+  }
+
+  # Email as sign-in
+  username_attributes      = ["email"]
+  auto_verified_attributes = ["email"]
+
+  # Custom attributes
+  schema {
+    name                = "role"
+    attribute_data_type = "String"
+    mutable             = true
+
+    string_attribute_constraints {
+      min_length = 1
+      max_length = 20
+    }
+  }
+
+  # Account recovery via email
+  account_recovery_setting {
+    recovery_mechanism {
+      name     = "verified_email"
+      priority = 1
+    }
+  }
+
+  tags = { Name = "fluxion-user-pool" }
+}
+
+# App Client
+resource "aws_cognito_user_pool_client" "main" {
+  name         = "fluxion-app-client"
+  user_pool_id = aws_cognito_user_pool.main.id
+
+  # Token expiry (NFR3.1)
+  access_token_validity  = 1   # 1 hour
+  id_token_validity      = 1   # 1 hour
+  refresh_token_validity = 30  # 30 days
+
+  token_validity_units {
+    access_token  = "hours"
+    id_token      = "hours"
+    refresh_token = "days"
+  }
+
+  # Auth flows
+  explicit_auth_flows = [
+    "ALLOW_USER_SRP_AUTH",
+    "ALLOW_REFRESH_TOKEN_AUTH",
+  ]
+
+  # Include custom:role in tokens
+  read_attributes  = ["email", "custom:role"]
+  write_attributes = ["email", "custom:role"]
+
+  # No client secret (SPA)
+  generate_secret = false
+}
+
+# Admin group
+resource "aws_cognito_user_group" "admin" {
+  name         = "ADMIN"
+  user_pool_id = aws_cognito_user_pool.main.id
+  description  = "Admin users with full access"
+}
+
+# Operator group
+resource "aws_cognito_user_group" "operator" {
+  name         = "OPERATOR"
+  user_pool_id = aws_cognito_user_pool.main.id
+  description  = "Operator users with standard access"
+}

--- a/fluxion-backend/infra/modules/auth/outputs.tf
+++ b/fluxion-backend/infra/modules/auth/outputs.tf
@@ -1,2 +1,11 @@
-# User pool ID, client ID
-# Implementation: issue #32
+output "user_pool_id" {
+  value = aws_cognito_user_pool.main.id
+}
+
+output "user_pool_arn" {
+  value = aws_cognito_user_pool.main.arn
+}
+
+output "client_id" {
+  value = aws_cognito_user_pool_client.main.id
+}

--- a/fluxion-backend/infra/outputs.tf
+++ b/fluxion-backend/infra/outputs.tf
@@ -19,3 +19,11 @@ output "rds_endpoint" {
 output "rds_proxy_endpoint" {
   value = module.database.rds_proxy_endpoint
 }
+
+output "cognito_user_pool_id" {
+  value = module.auth.user_pool_id
+}
+
+output "cognito_client_id" {
+  value = module.auth.client_id
+}

--- a/fluxion-backend/infra/ssm.tf
+++ b/fluxion-backend/infra/ssm.tf
@@ -29,3 +29,15 @@ resource "aws_ssm_parameter" "db_secret_arn" {
   type  = "String"
   value = module.database.db_secret_arn
 }
+
+resource "aws_ssm_parameter" "cognito_user_pool_id" {
+  name  = "/fluxion/auth/user_pool_id"
+  type  = "String"
+  value = module.auth.user_pool_id
+}
+
+resource "aws_ssm_parameter" "cognito_client_id" {
+  name  = "/fluxion/auth/client_id"
+  type  = "String"
+  value = module.auth.client_id
+}


### PR DESCRIPTION
## Summary

- Implement `modules/auth/`: Cognito User Pool, App Client (JWT 1h/30d refresh), custom:role attribute, ADMIN/OPERATOR groups
- Add `deploy.yml`: lint→test→terraform plan/apply→Docker build+push ECR (10 Lambda images)
- SSM exports for Cognito user_pool_id + client_id

## Commits (1 per phase)

| Phase | Scope |
|-------|-------|
| 1 | Cognito auth module + SSM exports |
| 2 | GitHub Actions deploy pipeline (lint→test→terraform→docker) |

## Test plan

- [x] `terraform validate` passes
- [ ] Cognito User Pool created with correct config (manual apply)
- [ ] JWT tokens contain `custom:role` claim (manual)
- [ ] Deploy pipeline triggers on main push (after merge)