### PR TITLE
[T7] Implement Lambda resolvers: action-resolver + upload-resolver

### DIFF
--- a/fluxion-backend/infra/modules/messaging/main.tf
+++ b/fluxion-backend/infra/modules/messaging/main.tf
@@ -1,2 +1,35 @@
-# SNS topics, SQS queues, DLQs
-# Implementation: issue #38
+# ─── Action Trigger Queue ─────────────────────────────────────────────────────
+
+resource "aws_sqs_queue" "action_trigger_dlq" {
+  name                      = "fluxion-${var.environment}-action-trigger-dlq"
+  message_retention_seconds = var.message_retention_seconds
+}
+
+resource "aws_sqs_queue" "action_trigger" {
+  name                       = "fluxion-${var.environment}-action-trigger-sqs"
+  visibility_timeout_seconds = var.visibility_timeout_seconds
+  message_retention_seconds  = var.message_retention_seconds
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.action_trigger_dlq.arn
+    maxReceiveCount     = var.dlq_max_receive_count
+  })
+}
+
+# ─── Upload Processor Queue ──────────────────────────────────────────────────
+
+resource "aws_sqs_queue" "upload_processor_dlq" {
+  name                      = "fluxion-${var.environment}-upload-processor-dlq"
+  message_retention_seconds = var.message_retention_seconds
+}
+
+resource "aws_sqs_queue" "upload_processor" {
+  name                       = "fluxion-${var.environment}-upload-processor-sqs"
+  visibility_timeout_seconds = var.visibility_timeout_seconds
+  message_retention_seconds  = var.message_retention_seconds
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.upload_processor_dlq.arn
+    maxReceiveCount     = var.dlq_max_receive_count
+  })
+}

--- a/fluxion-backend/infra/modules/messaging/outputs.tf
+++ b/fluxion-backend/infra/modules/messaging/outputs.tf
@@ -1,2 +1,26 @@
-# SNS topic ARNs, SQS queue URLs
-# Implementation: issue #38
+# Queue URLs — used as Lambda environment variables
+output "action_trigger_queue_url" {
+  value = aws_sqs_queue.action_trigger.url
+}
+
+output "upload_processor_queue_url" {
+  value = aws_sqs_queue.upload_processor.url
+}
+
+# Queue ARNs — used for IAM policies and Lambda event source mappings
+output "action_trigger_queue_arn" {
+  value = aws_sqs_queue.action_trigger.arn
+}
+
+output "upload_processor_queue_arn" {
+  value = aws_sqs_queue.upload_processor.arn
+}
+
+# DLQ ARNs — for monitoring/alerting
+output "action_trigger_dlq_arn" {
+  value = aws_sqs_queue.action_trigger_dlq.arn
+}
+
+output "upload_processor_dlq_arn" {
+  value = aws_sqs_queue.upload_processor_dlq.arn
+}

--- a/fluxion-backend/infra/modules/messaging/variables.tf
+++ b/fluxion-backend/infra/modules/messaging/variables.tf
@@ -2,3 +2,18 @@ variable "environment" {
   type    = string
   default = "dev"
 }
+
+variable "visibility_timeout_seconds" {
+  type    = number
+  default = 30
+}
+
+variable "message_retention_seconds" {
+  type    = number
+  default = 345600 # 4 days
+}
+
+variable "dlq_max_receive_count" {
+  type    = number
+  default = 3
+}

--- a/fluxion-backend/modules/action_resolver/requirements.txt
+++ b/fluxion-backend/modules/action_resolver/requirements.txt
@@ -1,2 +1,3 @@
 aws-lambda-powertools[all]==3.7.0
 psycopg[binary]==3.2.6
+boto3>=1.35.0

--- a/fluxion-backend/modules/action_resolver/src/config.py
+++ b/fluxion-backend/modules/action_resolver/src/config.py
@@ -1,8 +1,11 @@
 import os
 
+import boto3
 from aws_lambda_powertools import Logger, Tracer
 
 DATABASE_URL = os.environ.get("DATABASE_URL", "")
+SQS_QUEUE_URL = os.environ.get("SQS_QUEUE_URL", "")
 
 logger = Logger()
 tracer = Tracer()
+sqs_client = boto3.client("sqs")

--- a/fluxion-backend/modules/action_resolver/src/const.py
+++ b/fluxion-backend/modules/action_resolver/src/const.py
@@ -1,1 +1,4 @@
 """Constants for action_resolver."""
+
+ACTION_PENDING = "ACTION_PENDING"
+MAX_BULK_DEVICES = 100

--- a/fluxion-backend/modules/action_resolver/src/db.py
+++ b/fluxion-backend/modules/action_resolver/src/db.py
@@ -1,6 +1,36 @@
+"""Database queries for action_resolver. Uses explicit {schema}.table for tenant isolation."""
+
 import psycopg
-from config import DATABASE_URL
+from config import DATABASE_URL, logger
+from psycopg.rows import dict_row
 
 
-def get_connection():
-    return psycopg.connect(DATABASE_URL)
+class DBConnection:
+    """Singleton DB connection with tenant schema isolation via explicit schema-qualified tables."""
+
+    _conn: psycopg.Connection | None = None
+
+    @classmethod
+    def _get_conn(cls) -> psycopg.Connection:
+        if cls._conn is None or cls._conn.closed:
+            logger.info("Creating new database connection")
+            cls._conn = psycopg.connect(DATABASE_URL, autocommit=True, row_factory=dict_row)
+        return cls._conn
+
+    @classmethod
+    def get_device_for_action(cls, schema_name: str, device_id: str) -> dict | None:
+        """Fetch device id, state_id, assigned_action_id for FSM validation."""
+        conn = cls._get_conn()
+        return conn.execute(
+            f"SELECT id, state_id, assigned_action_id FROM {schema_name}.devices WHERE id = %(device_id)s",
+            {"device_id": device_id},
+        ).fetchone()
+
+    @classmethod
+    def get_action_by_id(cls, schema_name: str, action_id: str) -> dict | None:
+        """Fetch action for FSM guard validation."""
+        conn = cls._get_conn()
+        return conn.execute(
+            f"SELECT id, name, from_state_id, configuration FROM {schema_name}.actions WHERE id = %(action_id)s",
+            {"action_id": action_id},
+        ).fetchone()

--- a/fluxion-backend/modules/action_resolver/src/exceptions.py
+++ b/fluxion-backend/modules/action_resolver/src/exceptions.py
@@ -1,2 +1,32 @@
+"""Custom exceptions for action_resolver."""
+
+
 class FluxionError(Exception):
-    """Base exception for this module."""
+    """Base exception with error_type for AppSync error formatting."""
+
+    def __init__(self, message: str, error_type: str = "INTERNAL_ERROR"):
+        super().__init__(message)
+        self.error_type = error_type
+
+
+class DeviceNotFoundError(FluxionError):
+    def __init__(self, device_id: str):
+        super().__init__(f"Device {device_id} not found", "DEVICE_NOT_FOUND")
+
+
+class ActionNotFoundError(FluxionError):
+    def __init__(self, action_id: str):
+        super().__init__(f"Action {action_id} not found", "ACTION_NOT_FOUND")
+
+
+class DeviceBusyError(FluxionError):
+    def __init__(self, device_id: str):
+        super().__init__(f"Device {device_id} is busy", "DEVICE_BUSY")
+
+
+class InvalidTransitionError(FluxionError):
+    def __init__(self, device_state_id: int, action_name: str):
+        super().__init__(
+            f"Invalid transition: device in state {device_state_id}, action '{action_name}' not applicable",
+            "INVALID_TRANSITION",
+        )

--- a/fluxion-backend/modules/action_resolver/src/handler.py
+++ b/fluxion-backend/modules/action_resolver/src/handler.py
@@ -1,9 +1,141 @@
+"""Lambda handler for action_resolver — executeAction, executeBulkAction."""
+
+from uuid import uuid4
+
+from aws_lambda_powertools.event_handler import AppSyncResolver
 from aws_lambda_powertools.utilities.typing import LambdaContext
-from config import logger, tracer
+from config import SQS_QUEUE_URL, logger, tracer
+from const import ACTION_PENDING, MAX_BULK_DEVICES
+from db import DBConnection
+from exceptions import (
+    ActionNotFoundError,
+    DeviceBusyError,
+    DeviceNotFoundError,
+    FluxionError,
+    InvalidTransitionError,
+)
+from utils import get_tenant, send_message
+
+app = AppSyncResolver()
+
+
+@app.resolver(type_name="Mutation", field_name="executeAction")
+def execute_action(input: dict) -> dict:
+    tenant = get_tenant(app)
+    device_id = input["deviceId"]
+    action_id = input["actionId"]
+    try:
+        # 1. Get device
+        device = DBConnection.get_device_for_action(schema_name=tenant, device_id=device_id)
+        if not device:
+            raise DeviceNotFoundError(device_id)
+
+        # 2. Guard: device not busy
+        if device["assigned_action_id"] is not None:
+            raise DeviceBusyError(device_id)
+
+        # 3. Get action + guard: valid transition
+        action = DBConnection.get_action_by_id(schema_name=tenant, action_id=action_id)
+        if not action:
+            raise ActionNotFoundError(action_id)
+        if action["from_state_id"] != device["state_id"]:
+            raise InvalidTransitionError(device["state_id"], action["name"])
+
+        # TODO: Guard 3 — RBAC (release = admin only) — separate ticket
+
+        # 4. Pre-generate IDs
+        execution_id = str(uuid4())
+        command_uuid = str(uuid4())
+
+        # 5. Enqueue to SQS
+        message_body = {
+            "executionId": execution_id,
+            "commandUuid": command_uuid,
+            "deviceId": device_id,
+            "actionId": action_id,
+            "configuration": input.get("configuration"),
+            "tenantId": tenant,
+        }
+        send_message(SQS_QUEUE_URL, message_body)
+
+        return {
+            "executionId": execution_id,
+            "commandUuid": command_uuid,
+            "status": ACTION_PENDING,
+        }
+    except FluxionError:
+        raise
+    except Exception:
+        logger.exception("Unexpected error in executeAction")
+        raise
+
+
+@app.resolver(type_name="Mutation", field_name="executeBulkAction")
+def execute_bulk_action(input: dict) -> dict:
+    tenant = get_tenant(app)
+    device_ids = input["deviceIds"]
+    action_id = input["actionId"]
+    configuration = input.get("configuration")
+
+    if len(device_ids) > MAX_BULK_DEVICES:
+        raise FluxionError(f"Exceeds max bulk limit of {MAX_BULK_DEVICES}", "VALIDATION_ERROR")
+
+    # Fetch action once outside loop to avoid N+1
+    action = DBConnection.get_action_by_id(schema_name=tenant, action_id=action_id)
+    if not action:
+        raise ActionNotFoundError(action_id)
+
+    valid = []
+    failed = []
+    for device_id in device_ids:
+        try:
+            # 1. Get device
+            device = DBConnection.get_device_for_action(schema_name=tenant, device_id=device_id)
+            if not device:
+                raise DeviceNotFoundError(device_id)
+
+            # 2. Guard: device not busy
+            if device["assigned_action_id"] is not None:
+                raise DeviceBusyError(device_id)
+
+            # 3. Guard: valid transition
+            if action["from_state_id"] != device["state_id"]:
+                raise InvalidTransitionError(device["state_id"], action["name"])
+
+            # TODO: Guard 3 — RBAC (release = admin only) — separate ticket
+
+            # 4. Pre-generate IDs
+            execution_id = str(uuid4())
+            command_uuid = str(uuid4())
+
+            # 5. Enqueue to SQS
+            message_body = {
+                "executionId": execution_id,
+                "commandUuid": command_uuid,
+                "deviceId": device_id,
+                "actionId": action_id,
+                "configuration": configuration,
+                "tenantId": tenant,
+            }
+            send_message(SQS_QUEUE_URL, message_body)
+
+            valid.append({
+                "executionId": execution_id,
+                "commandUuid": command_uuid,
+                "status": ACTION_PENDING,
+            })
+        except FluxionError as e:
+            failed.append({"deviceId": device_id, "reason": str(e)})
+        except Exception:
+            logger.exception(f"Unexpected error for device {device_id}")
+            failed.append({"deviceId": device_id, "reason": "Internal error"})
+
+    return {"valid": valid, "failed": failed}
 
 
 @logger.inject_lambda_context
 @tracer.capture_lambda_handler
 def handler(event: dict, context: LambdaContext) -> dict:
-    """Lambda handler for action_resolver."""
-    raise NotImplementedError
+    """Lambda entry point — dispatches to AppSyncResolver."""
+    logger.debug("Event received", extra={"event": event})
+    return app.resolve(event, context)

--- a/fluxion-backend/modules/action_resolver/src/tests/test_handler.py
+++ b/fluxion-backend/modules/action_resolver/src/tests/test_handler.py
@@ -11,6 +11,7 @@ with patch.dict(
         "POWERTOOLS_SERVICE_NAME": "test",
         "POWERTOOLS_TRACE_DISABLED": "1",
         "SQS_QUEUE_URL": "https://sqs.ap-southeast-1.amazonaws.com/123456789/test-queue",
+        "AWS_DEFAULT_REGION": "ap-southeast-1",
     },
 ):
     from db import DBConnection

--- a/fluxion-backend/modules/action_resolver/src/tests/test_handler.py
+++ b/fluxion-backend/modules/action_resolver/src/tests/test_handler.py
@@ -1,5 +1,183 @@
-"""Tests for action_resolver handler."""
+"""Tests for action_resolver handler — mock DBConnection + SQS, test FSM validation."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Mock config before importing handler (Lambda Powertools needs env vars)
+with patch.dict(
+    "os.environ",
+    {
+        "POWERTOOLS_SERVICE_NAME": "test",
+        "POWERTOOLS_TRACE_DISABLED": "1",
+        "SQS_QUEUE_URL": "https://sqs.ap-southeast-1.amazonaws.com/123456789/test-queue",
+    },
+):
+    from db import DBConnection
+    from handler import app
+
+TENANT = "test_tenant"
+
+MOCK_DEVICE = {
+    "id": "d-001",
+    "state_id": 1,
+    "assigned_action_id": None,
+}
+
+MOCK_DEVICE_BUSY = {
+    "id": "d-002",
+    "state_id": 1,
+    "assigned_action_id": "a-existing",
+}
+
+MOCK_ACTION = {
+    "id": "a-001",
+    "name": "Lock",
+    "from_state_id": 1,
+    "configuration": None,
+}
+
+MOCK_ACTION_WRONG_STATE = {
+    "id": "a-002",
+    "name": "Unlock",
+    "from_state_id": 3,
+    "configuration": None,
+}
 
 
-def test_placeholder():
-    assert True
+def _make_appsync_event(field_name: str, arguments: dict, type_name: str = "Mutation") -> dict:
+    """Build a minimal AppSync resolver event."""
+    return {
+        "typeName": type_name,
+        "fieldName": field_name,
+        "arguments": arguments,
+        "identity": {
+            "claims": {
+                "custom:tenant_id": TENANT,
+                "custom:role": "ADMIN",
+                "sub": "cognito-sub-123",
+            },
+            "sub": "cognito-sub-123",
+        },
+        "info": {
+            "fieldName": field_name,
+            "parentTypeName": type_name,
+            "selectionSetList": [],
+        },
+    }
+
+
+class TestExecuteAction:
+    @patch("handler.send_message")
+    @patch.object(DBConnection, "get_action_by_id")
+    @patch.object(DBConnection, "get_device_for_action")
+    def test_happy_path(self, mock_device, mock_action, mock_send):
+        mock_device.return_value = MOCK_DEVICE
+        mock_action.return_value = MOCK_ACTION
+        event = _make_appsync_event(
+            "executeAction", {"input": {"deviceId": "d-001", "actionId": "a-001"}}
+        )
+        result = app.resolve(event, MagicMock())
+
+        assert result["executionId"] is not None
+        assert result["commandUuid"] is not None
+        assert result["status"] == "ACTION_PENDING"
+        mock_send.assert_called_once()
+
+        # Verify SQS payload (second positional arg = body dict)
+        call_body = mock_send.call_args[0][1]
+        assert call_body["deviceId"] == "d-001"
+        assert call_body["actionId"] == "a-001"
+        assert call_body["tenantId"] == TENANT
+        assert call_body["executionId"] == result["executionId"]
+        assert call_body["commandUuid"] == result["commandUuid"]
+
+    @patch("handler.send_message")
+    @patch.object(DBConnection, "get_device_for_action")
+    def test_device_not_found(self, mock_device, mock_send):
+        mock_device.return_value = None
+        event = _make_appsync_event(
+            "executeAction", {"input": {"deviceId": "nonexistent", "actionId": "a-001"}}
+        )
+
+        with pytest.raises(Exception, match="not found"):
+            app.resolve(event, MagicMock())
+        mock_send.assert_not_called()
+
+    @patch("handler.send_message")
+    @patch.object(DBConnection, "get_device_for_action")
+    def test_device_busy(self, mock_device, mock_send):
+        mock_device.return_value = MOCK_DEVICE_BUSY
+        event = _make_appsync_event(
+            "executeAction", {"input": {"deviceId": "d-002", "actionId": "a-001"}}
+        )
+
+        with pytest.raises(Exception, match="is busy"):
+            app.resolve(event, MagicMock())
+        mock_send.assert_not_called()
+
+    @patch("handler.send_message")
+    @patch.object(DBConnection, "get_action_by_id")
+    @patch.object(DBConnection, "get_device_for_action")
+    def test_invalid_transition(self, mock_device, mock_action, mock_send):
+        mock_device.return_value = MOCK_DEVICE  # state_id=1
+        mock_action.return_value = MOCK_ACTION_WRONG_STATE  # from_state_id=3
+        event = _make_appsync_event(
+            "executeAction", {"input": {"deviceId": "d-001", "actionId": "a-002"}}
+        )
+
+        with pytest.raises(Exception, match="Invalid transition"):
+            app.resolve(event, MagicMock())
+        mock_send.assert_not_called()
+
+    @patch("handler.send_message")
+    @patch.object(DBConnection, "get_action_by_id")
+    @patch.object(DBConnection, "get_device_for_action")
+    def test_action_not_found(self, mock_device, mock_action, mock_send):
+        mock_device.return_value = MOCK_DEVICE
+        mock_action.return_value = None
+        event = _make_appsync_event(
+            "executeAction", {"input": {"deviceId": "d-001", "actionId": "nonexistent"}}
+        )
+
+        with pytest.raises(Exception, match="not found"):
+            app.resolve(event, MagicMock())
+        mock_send.assert_not_called()
+
+
+class TestExecuteBulkAction:
+    @patch("handler.send_message")
+    @patch.object(DBConnection, "get_action_by_id")
+    @patch.object(DBConnection, "get_device_for_action")
+    def test_mixed_results(self, mock_device, mock_action, mock_send):
+        """2 valid devices + 1 busy device → partial response."""
+        mock_device.side_effect = [MOCK_DEVICE, MOCK_DEVICE_BUSY, MOCK_DEVICE]
+        mock_action.return_value = MOCK_ACTION
+        event = _make_appsync_event(
+            "executeBulkAction",
+            {"input": {"deviceIds": ["d-001", "d-002", "d-003"], "actionId": "a-001"}},
+        )
+        result = app.resolve(event, MagicMock())
+
+        assert len(result["valid"]) == 2
+        assert len(result["failed"]) == 1
+        assert result["failed"][0]["deviceId"] == "d-002"
+        assert "busy" in result["failed"][0]["reason"].lower()
+        assert mock_send.call_count == 2
+
+    @patch("handler.send_message")
+    @patch.object(DBConnection, "get_action_by_id")
+    @patch.object(DBConnection, "get_device_for_action")
+    def test_all_fail(self, mock_device, mock_action, mock_send):
+        """All devices busy → empty valid, all failed."""
+        mock_device.return_value = MOCK_DEVICE_BUSY
+        mock_action.return_value = MOCK_ACTION
+        event = _make_appsync_event(
+            "executeBulkAction",
+            {"input": {"deviceIds": ["d-001", "d-002"], "actionId": "a-001"}},
+        )
+        result = app.resolve(event, MagicMock())
+
+        assert len(result["valid"]) == 0
+        assert len(result["failed"]) == 2
+        mock_send.assert_not_called()

--- a/fluxion-backend/modules/action_resolver/src/utils.py
+++ b/fluxion-backend/modules/action_resolver/src/utils.py
@@ -1,1 +1,24 @@
 """Utility functions for action_resolver."""
+
+import json
+import re
+
+from config import sqs_client
+
+
+def send_message(queue_url: str, message_body: dict) -> None:
+    """Send a JSON message to an SQS queue."""
+    sqs_client.send_message(QueueUrl=queue_url, MessageBody=json.dumps(message_body))
+
+
+def validate_tenant_id(tenant_id: str) -> str:
+    """Validate tenant_id format (alphanumeric + underscore only) to prevent SQL injection."""
+    if not re.match(r"^[a-zA-Z0-9_]+$", tenant_id):
+        raise ValueError("Invalid tenant_id format")
+    return tenant_id
+
+
+def get_tenant(app_instance) -> str:
+    """Extract and validate tenant_id from JWT claims."""
+    tenant_id = app_instance.current_event.identity.claims["custom:tenant_id"]
+    return validate_tenant_id(tenant_id)

--- a/fluxion-backend/modules/upload_resolver/requirements.txt
+++ b/fluxion-backend/modules/upload_resolver/requirements.txt
@@ -1,2 +1,3 @@
 aws-lambda-powertools[all]==3.7.0
 psycopg[binary]==3.2.6
+boto3>=1.35.0

--- a/fluxion-backend/modules/upload_resolver/src/config.py
+++ b/fluxion-backend/modules/upload_resolver/src/config.py
@@ -1,8 +1,11 @@
 import os
 
+import boto3
 from aws_lambda_powertools import Logger, Tracer
 
 DATABASE_URL = os.environ.get("DATABASE_URL", "")
+SQS_QUEUE_URL = os.environ.get("SQS_QUEUE_URL", "")
 
 logger = Logger()
 tracer = Tracer()
+sqs_client = boto3.client("sqs")

--- a/fluxion-backend/modules/upload_resolver/src/const.py
+++ b/fluxion-backend/modules/upload_resolver/src/const.py
@@ -1,1 +1,10 @@
 """Constants for upload_resolver."""
+
+MAX_UPLOAD_DEVICES = 5000
+
+REASON_EMPTY_SERIAL = "serialNumber is empty"
+REASON_EMPTY_UDID = "udid is empty"
+REASON_DUPLICATE_SERIAL_BATCH = "Duplicate serialNumber in batch"
+REASON_DUPLICATE_UDID_BATCH = "Duplicate udid in batch"
+REASON_SERIAL_EXISTS = "serialNumber already exists"
+REASON_UDID_EXISTS = "udid already exists"

--- a/fluxion-backend/modules/upload_resolver/src/db.py
+++ b/fluxion-backend/modules/upload_resolver/src/db.py
@@ -1,6 +1,33 @@
+"""Database queries for upload_resolver. Uses explicit {schema}.table for tenant isolation."""
+
 import psycopg
-from config import DATABASE_URL
+from config import DATABASE_URL, logger
+from psycopg.rows import dict_row
 
 
-def get_connection():
-    return psycopg.connect(DATABASE_URL)
+class DBConnection:
+    """Singleton DB connection with tenant schema isolation via explicit schema-qualified tables."""
+
+    _conn: psycopg.Connection | None = None
+
+    @classmethod
+    def _get_conn(cls) -> psycopg.Connection:
+        if cls._conn is None or cls._conn.closed:
+            logger.info("Creating new database connection")
+            cls._conn = psycopg.connect(DATABASE_URL, autocommit=True, row_factory=dict_row)
+        return cls._conn
+
+    @classmethod
+    def find_existing_identifiers(
+        cls, schema_name: str, serial_numbers: list[str], udids: list[str]
+    ) -> list[dict]:
+        """Find device_informations rows matching any of the given serial_numbers or udids."""
+        conn = cls._get_conn()
+        return conn.execute(
+            f"""
+            SELECT serial_number, udid
+            FROM {schema_name}.device_informations
+            WHERE serial_number = ANY(%(serials)s) OR udid = ANY(%(udids)s)
+            """,
+            {"serials": serial_numbers, "udids": udids},
+        ).fetchall()

--- a/fluxion-backend/modules/upload_resolver/src/exceptions.py
+++ b/fluxion-backend/modules/upload_resolver/src/exceptions.py
@@ -1,2 +1,9 @@
+"""Custom exceptions for upload_resolver."""
+
+
 class FluxionError(Exception):
-    """Base exception for this module."""
+    """Base exception with error_type for AppSync error formatting."""
+
+    def __init__(self, message: str, error_type: str = "INTERNAL_ERROR"):
+        super().__init__(message)
+        self.error_type = error_type

--- a/fluxion-backend/modules/upload_resolver/src/handler.py
+++ b/fluxion-backend/modules/upload_resolver/src/handler.py
@@ -1,9 +1,112 @@
+"""Lambda handler for upload_resolver — uploadDevices."""
+
+from aws_lambda_powertools.event_handler import AppSyncResolver
 from aws_lambda_powertools.utilities.typing import LambdaContext
-from config import logger, tracer
+from config import SQS_QUEUE_URL, logger, tracer
+from const import (
+    MAX_UPLOAD_DEVICES,
+    REASON_DUPLICATE_SERIAL_BATCH,
+    REASON_DUPLICATE_UDID_BATCH,
+    REASON_EMPTY_SERIAL,
+    REASON_EMPTY_UDID,
+    REASON_SERIAL_EXISTS,
+    REASON_UDID_EXISTS,
+)
+from db import DBConnection
+from exceptions import FluxionError
+from utils import get_tenant, send_message
+
+app = AppSyncResolver()
+
+
+@app.resolver(type_name="Mutation", field_name="uploadDevices")
+def upload_devices(devices: list[dict]) -> dict:
+    tenant = get_tenant(app)
+    total = len(devices)
+
+    if total > MAX_UPLOAD_DEVICES:
+        raise FluxionError(f"Exceeds max upload limit of {MAX_UPLOAD_DEVICES}", "VALIDATION_ERROR")
+
+    errors = []
+    accepted_indices = set(range(total))
+
+    # Stage 1: Format validation — serialNumber + udid non-empty
+    for i, dev in enumerate(devices):
+        if not dev.get("serialNumber", "").strip():
+            errors.append({"index": i, "serialNumber": dev.get("serialNumber"), "reason": REASON_EMPTY_SERIAL})
+            accepted_indices.discard(i)
+        elif not dev.get("udid", "").strip():
+            errors.append({"index": i, "serialNumber": dev.get("serialNumber"), "reason": REASON_EMPTY_UDID})
+            accepted_indices.discard(i)
+
+    # Stage 2: Intra-batch duplicate detection
+    seen_serials: dict[str, int] = {}
+    seen_udids: dict[str, int] = {}
+    for i in sorted(accepted_indices):
+        serial = devices[i]["serialNumber"]
+        udid = devices[i]["udid"]
+        if serial in seen_serials:
+            errors.append({"index": i, "serialNumber": serial, "reason": REASON_DUPLICATE_SERIAL_BATCH})
+            accepted_indices.discard(i)
+        elif udid in seen_udids:
+            errors.append({"index": i, "serialNumber": serial, "reason": REASON_DUPLICATE_UDID_BATCH})
+            accepted_indices.discard(i)
+        else:
+            seen_serials[serial] = i
+            seen_udids[udid] = i
+
+    # Stage 3: DB duplicate check (only for remaining accepted)
+    if accepted_indices:
+        try:
+            serials = [devices[i]["serialNumber"] for i in accepted_indices]
+            udids = [devices[i]["udid"] for i in accepted_indices]
+            existing = DBConnection.find_existing_identifiers(tenant, serials, udids)
+
+            existing_serials = {r["serial_number"] for r in existing}
+            existing_udids = {r["udid"] for r in existing}
+
+            for i in sorted(accepted_indices):
+                serial = devices[i]["serialNumber"]
+                udid = devices[i]["udid"]
+                if serial in existing_serials:
+                    errors.append({"index": i, "serialNumber": serial, "reason": REASON_SERIAL_EXISTS})
+                    accepted_indices.discard(i)
+                elif udid in existing_udids:
+                    errors.append({"index": i, "serialNumber": serial, "reason": REASON_UDID_EXISTS})
+                    accepted_indices.discard(i)
+        except FluxionError:
+            raise
+        except Exception:
+            logger.exception("Unexpected error during DB duplicate check")
+            raise
+
+    # Enqueue accepted devices to SQS
+    for i in accepted_indices:
+        dev = devices[i]
+        message_body = {
+            "serialNumber": dev["serialNumber"],
+            "udid": dev["udid"],
+            "name": dev.get("name"),
+            "model": dev.get("model"),
+            "osVersion": dev.get("osVersion"),
+            "tenantId": tenant,
+        }
+        send_message(SQS_QUEUE_URL, message_body)
+
+    # Sort errors by index for consistent output
+    errors.sort(key=lambda e: e["index"])
+
+    return {
+        "totalRequested": total,
+        "accepted": len(accepted_indices),
+        "rejected": total - len(accepted_indices),
+        "errors": errors if errors else None,
+    }
 
 
 @logger.inject_lambda_context
 @tracer.capture_lambda_handler
 def handler(event: dict, context: LambdaContext) -> dict:
-    """Lambda handler for upload_resolver."""
-    raise NotImplementedError
+    """Lambda entry point — dispatches to AppSyncResolver."""
+    logger.debug("Event received", extra={"event": event})
+    return app.resolve(event, context)

--- a/fluxion-backend/modules/upload_resolver/src/tests/test_handler.py
+++ b/fluxion-backend/modules/upload_resolver/src/tests/test_handler.py
@@ -1,5 +1,182 @@
-"""Tests for upload_resolver handler."""
+"""Tests for upload_resolver handler — mock DBConnection + SQS, test validation pipeline."""
+
+from unittest.mock import MagicMock, patch
+
+# Mock config before importing handler (Lambda Powertools needs env vars)
+with patch.dict(
+    "os.environ",
+    {
+        "POWERTOOLS_SERVICE_NAME": "test",
+        "POWERTOOLS_TRACE_DISABLED": "1",
+        "SQS_QUEUE_URL": "https://sqs.ap-southeast-1.amazonaws.com/123456789/test-queue",
+    },
+):
+    from db import DBConnection
+    from handler import app
+
+TENANT = "test_tenant"
 
 
-def test_placeholder():
-    assert True
+def _make_appsync_event(field_name: str, arguments: dict, type_name: str = "Mutation") -> dict:
+    """Build a minimal AppSync resolver event."""
+    return {
+        "typeName": type_name,
+        "fieldName": field_name,
+        "arguments": arguments,
+        "identity": {
+            "claims": {
+                "custom:tenant_id": TENANT,
+                "custom:role": "ADMIN",
+                "sub": "cognito-sub-123",
+            },
+            "sub": "cognito-sub-123",
+        },
+        "info": {
+            "fieldName": field_name,
+            "parentTypeName": type_name,
+            "selectionSetList": [],
+        },
+    }
+
+
+def _device(serial: str, udid: str, name: str = "iPhone") -> dict:
+    return {"serialNumber": serial, "udid": udid, "name": name, "model": "iPhone15,2", "osVersion": "17.0"}
+
+
+class TestUploadDevices:
+    @patch("handler.send_message")
+    @patch.object(DBConnection, "find_existing_identifiers")
+    def test_happy_path(self, mock_db, mock_send):
+        """3 valid devices → accepted=3, rejected=0, SQS called 3x."""
+        mock_db.return_value = []
+        devices = [_device("SN1", "UD1"), _device("SN2", "UD2"), _device("SN3", "UD3")]
+        event = _make_appsync_event("uploadDevices", {"devices": devices})
+        result = app.resolve(event, MagicMock())
+
+        assert result["totalRequested"] == 3
+        assert result["accepted"] == 3
+        assert result["rejected"] == 0
+        assert result["errors"] is None
+        assert mock_send.call_count == 3
+
+    @patch("handler.send_message")
+    @patch.object(DBConnection, "find_existing_identifiers")
+    def test_empty_serial_number(self, mock_db, mock_send):
+        mock_db.return_value = []
+        devices = [{"serialNumber": "", "udid": "UD1"}, _device("SN2", "UD2")]
+        event = _make_appsync_event("uploadDevices", {"devices": devices})
+        result = app.resolve(event, MagicMock())
+
+        assert result["accepted"] == 1
+        assert result["rejected"] == 1
+        assert result["errors"][0]["index"] == 0
+        assert "empty" in result["errors"][0]["reason"].lower()
+        assert mock_send.call_count == 1
+
+    @patch("handler.send_message")
+    @patch.object(DBConnection, "find_existing_identifiers")
+    def test_empty_udid(self, mock_db, mock_send):
+        mock_db.return_value = []
+        devices = [{"serialNumber": "SN1", "udid": "  "}, _device("SN2", "UD2")]
+        event = _make_appsync_event("uploadDevices", {"devices": devices})
+        result = app.resolve(event, MagicMock())
+
+        assert result["accepted"] == 1
+        assert result["rejected"] == 1
+        assert "udid" in result["errors"][0]["reason"].lower()
+
+    @patch("handler.send_message")
+    @patch.object(DBConnection, "find_existing_identifiers")
+    def test_intra_batch_duplicate_serial(self, mock_db, mock_send):
+        """2 devices with same serial → first accepted, second rejected."""
+        mock_db.return_value = []
+        devices = [_device("SN1", "UD1"), _device("SN1", "UD2")]
+        event = _make_appsync_event("uploadDevices", {"devices": devices})
+        result = app.resolve(event, MagicMock())
+
+        assert result["accepted"] == 1
+        assert result["rejected"] == 1
+        assert result["errors"][0]["index"] == 1
+        assert "Duplicate serialNumber" in result["errors"][0]["reason"]
+        assert mock_send.call_count == 1
+
+    @patch("handler.send_message")
+    @patch.object(DBConnection, "find_existing_identifiers")
+    def test_intra_batch_duplicate_udid(self, mock_db, mock_send):
+        """2 devices with same udid → first accepted, second rejected."""
+        mock_db.return_value = []
+        devices = [_device("SN1", "UD1"), _device("SN2", "UD1")]
+        event = _make_appsync_event("uploadDevices", {"devices": devices})
+        result = app.resolve(event, MagicMock())
+
+        assert result["accepted"] == 1
+        assert result["rejected"] == 1
+        assert "Duplicate udid" in result["errors"][0]["reason"]
+
+    @patch("handler.send_message")
+    @patch.object(DBConnection, "find_existing_identifiers")
+    def test_db_duplicate_serial(self, mock_db, mock_send):
+        """Serial already in DB → rejected."""
+        mock_db.return_value = [{"serial_number": "SN1", "udid": "EXISTING_UD"}]
+        devices = [_device("SN1", "UD_NEW"), _device("SN2", "UD2")]
+        event = _make_appsync_event("uploadDevices", {"devices": devices})
+        result = app.resolve(event, MagicMock())
+
+        assert result["accepted"] == 1
+        assert result["rejected"] == 1
+        assert "already exists" in result["errors"][0]["reason"]
+        assert mock_send.call_count == 1
+
+    @patch("handler.send_message")
+    @patch.object(DBConnection, "find_existing_identifiers")
+    def test_db_duplicate_udid(self, mock_db, mock_send):
+        """UDID already in DB → rejected."""
+        mock_db.return_value = [{"serial_number": "EXISTING_SN", "udid": "UD1"}]
+        devices = [_device("SN_NEW", "UD1"), _device("SN2", "UD2")]
+        event = _make_appsync_event("uploadDevices", {"devices": devices})
+        result = app.resolve(event, MagicMock())
+
+        assert result["accepted"] == 1
+        assert result["rejected"] == 1
+        assert "udid already exists" in result["errors"][0]["reason"]
+
+    @patch("handler.send_message")
+    @patch.object(DBConnection, "find_existing_identifiers")
+    def test_mixed_batch(self, mock_db, mock_send):
+        """5 devices: 2 valid + 1 empty + 1 batch-dup + 1 DB-dup."""
+        mock_db.return_value = [{"serial_number": "SN5", "udid": "UD5_OLD"}]
+        devices = [
+            _device("SN1", "UD1"),              # valid
+            {"serialNumber": "", "udid": "UD2"},  # empty serial
+            _device("SN1", "UD3"),              # batch-dup serial (SN1)
+            _device("SN4", "UD4"),              # valid
+            _device("SN5", "UD5"),              # DB-dup serial
+        ]
+        event = _make_appsync_event("uploadDevices", {"devices": devices})
+        result = app.resolve(event, MagicMock())
+
+        assert result["totalRequested"] == 5
+        assert result["accepted"] == 2
+        assert result["rejected"] == 3
+        assert len(result["errors"]) == 3
+        # Errors sorted by index
+        assert result["errors"][0]["index"] == 1
+        assert result["errors"][1]["index"] == 2
+        assert result["errors"][2]["index"] == 4
+        assert mock_send.call_count == 2
+
+    @patch("handler.send_message")
+    @patch.object(DBConnection, "find_existing_identifiers")
+    def test_all_rejected(self, mock_db, mock_send):
+        """All devices fail → accepted=0, SQS never called."""
+        mock_db.return_value = []
+        devices = [
+            {"serialNumber": "", "udid": "UD1"},
+            {"serialNumber": "SN2", "udid": ""},
+        ]
+        event = _make_appsync_event("uploadDevices", {"devices": devices})
+        result = app.resolve(event, MagicMock())
+
+        assert result["accepted"] == 0
+        assert result["rejected"] == 2
+        mock_send.assert_not_called()

--- a/fluxion-backend/modules/upload_resolver/src/tests/test_handler.py
+++ b/fluxion-backend/modules/upload_resolver/src/tests/test_handler.py
@@ -9,6 +9,7 @@ with patch.dict(
         "POWERTOOLS_SERVICE_NAME": "test",
         "POWERTOOLS_TRACE_DISABLED": "1",
         "SQS_QUEUE_URL": "https://sqs.ap-southeast-1.amazonaws.com/123456789/test-queue",
+        "AWS_DEFAULT_REGION": "ap-southeast-1",
     },
 ):
     from db import DBConnection

--- a/fluxion-backend/modules/upload_resolver/src/utils.py
+++ b/fluxion-backend/modules/upload_resolver/src/utils.py
@@ -1,1 +1,24 @@
 """Utility functions for upload_resolver."""
+
+import json
+import re
+
+from config import sqs_client
+
+
+def send_message(queue_url: str, message_body: dict) -> None:
+    """Send a JSON message to an SQS queue."""
+    sqs_client.send_message(QueueUrl=queue_url, MessageBody=json.dumps(message_body))
+
+
+def validate_tenant_id(tenant_id: str) -> str:
+    """Validate tenant_id format (alphanumeric + underscore only) to prevent SQL injection."""
+    if not re.match(r"^[a-zA-Z0-9_]+$", tenant_id):
+        raise ValueError("Invalid tenant_id format")
+    return tenant_id
+
+
+def get_tenant(app_instance) -> str:
+    """Extract and validate tenant_id from JWT claims."""
+    tenant_id = app_instance.current_event.identity.claims["custom:tenant_id"]
+    return validate_tenant_id(tenant_id)


### PR DESCRIPTION
## Summary
- Implement `action_resolver` with `executeAction` + `executeBulkAction` mutations — FSM guards (DEVICE_NOT_FOUND, DEVICE_BUSY, INVALID_TRANSITION) → SQS enqueue
- Implement `upload_resolver` with `uploadDevices` mutation — 3-stage validation (format, intra-batch duplicates, DB duplicates) → SQS enqueue
- Add Terraform SQS messaging module: 2 standard queues + 2 DLQs with redrive policies

Both resolvers are validate-and-enqueue only — no DB writes. Downstream workers (`action_trigger`, `upload_processor`) handle persistence after dequeue.

## Key Design Decisions
- Pre-generate `executionId` + `commandUuid` (uuid4) in resolver for immediate return to caller
- RBAC Guard 3 (release = admin only) deferred to separate ticket — marked as TODO
- Batch size caps: `MAX_BULK_DEVICES=100`, `MAX_UPLOAD_DEVICES=5000`
- `executeBulkAction` fetches action once outside loop (avoids N+1)

## Changes
- `modules/action_resolver/src/` — 7 files (config, const, db, exceptions, handler, utils, tests)
- `modules/upload_resolver/src/` — 7 files (config, const, db, exceptions, handler, utils, tests)
- `infra/modules/messaging/` — 3 Terraform files (main.tf, variables.tf, outputs.tf)
- Both `requirements.txt` — added `boto3>=1.35.0`

## Test Plan
- [x] `pytest` action_resolver: 7 tests (happy path, all 4 error guards, bulk mixed, bulk all-fail)
- [x] `pytest` upload_resolver: 9 tests (happy path, empty serial/udid, intra-batch dup serial/udid, DB dup serial/udid, mixed batch, all rejected)
- [x] `ruff check` clean for both modules
- [x] `terraform validate` passes

Closes #35