### PR TITLE
[T7] Implement Lambda workers: action-trigger, upload-processor, checkin-handler

### DIFF
--- a/fluxion-backend/infra/main.tf
+++ b/fluxion-backend/infra/main.tf
@@ -65,6 +65,35 @@ module "api" {
 module "compute" {
   source      = "./modules/compute"
   environment = var.environment
+  region      = var.region
+
+  # Network
+  private_subnet_ids = module.network.private_subnet_ids
+  lambda_sg_id       = module.network.lambda_sg_id
+
+  # Database
+  db_secret_arn = module.database.db_secret_arn
+  database_url  = "postgresql://${module.database.db_username}:${var.db_password}@${module.database.rds_proxy_endpoint}/${module.database.db_name}"
+
+  # Messaging — queue URLs (for Lambda env vars)
+  action_trigger_queue_url  = module.messaging.action_trigger_queue_url
+  upload_processor_queue_url = module.messaging.upload_processor_queue_url
+
+  # Messaging — queue ARNs (for IAM + event source mappings)
+  action_trigger_queue_arn  = module.messaging.action_trigger_queue_arn
+  upload_processor_queue_arn = module.messaging.upload_processor_queue_arn
+  checkin_handler_queue_arn  = module.messaging.checkin_handler_queue_arn
+
+  # SNS
+  command_sns_topic_arn = module.messaging.command_sns_topic_arn
+
+  # AppSync
+  appsync_endpoint = module.api.api_url
+  appsync_api_arn  = module.api.api_arn
+
+  # DynamoDB
+  idempotency_table_name = module.messaging.idempotency_table_name
+  idempotency_table_arn  = module.messaging.idempotency_table_arn
 }
 
 module "messaging" {

--- a/fluxion-backend/infra/modules/compute/main.tf
+++ b/fluxion-backend/infra/modules/compute/main.tf
@@ -1,2 +1,253 @@
-# Lambda functions (resolvers + workers), ECR repos
-# Implementation: issues #34, #35, #36
+# All BE Lambda functions (6 resolvers + 3 workers), ECR repos, IAM roles, SQS event source mappings
+
+locals {
+  lambdas = {
+    device_resolver = {
+      memory  = 256
+      timeout = 30
+      env_vars = {
+        DATABASE_URL = var.database_url
+      }
+      sqs_trigger = null
+    }
+    platform_resolver = {
+      memory  = 256
+      timeout = 30
+      env_vars = {
+        DATABASE_URL = var.database_url
+      }
+      sqs_trigger = null
+    }
+    user_resolver = {
+      memory  = 256
+      timeout = 30
+      env_vars = {
+        DATABASE_URL = var.database_url
+      }
+      sqs_trigger = null
+    }
+    action_resolver = {
+      memory  = 256
+      timeout = 30
+      env_vars = {
+        DATABASE_URL  = var.database_url
+        SQS_QUEUE_URL = var.action_trigger_queue_url
+      }
+      sqs_trigger = null
+    }
+    upload_resolver = {
+      memory  = 256
+      timeout = 30
+      env_vars = {
+        DATABASE_URL  = var.database_url
+        SQS_QUEUE_URL = var.upload_processor_queue_url
+      }
+      sqs_trigger = null
+    }
+    chat_resolver = {
+      memory  = 256
+      timeout = 30
+      env_vars = {
+        DATABASE_URL = var.database_url
+      }
+      sqs_trigger = null
+    }
+    action_trigger = {
+      memory  = 512
+      timeout = 60
+      env_vars = {
+        DATABASE_URL           = var.database_url
+        SNS_TOPIC_ARN          = var.command_sns_topic_arn
+        IDEMPOTENCY_TABLE_NAME = var.idempotency_table_name
+      }
+      sqs_trigger = var.action_trigger_queue_arn
+    }
+    upload_processor = {
+      memory  = 256
+      timeout = 30
+      env_vars = {
+        DATABASE_URL = var.database_url
+      }
+      sqs_trigger = var.upload_processor_queue_arn
+    }
+    checkin_handler = {
+      memory  = 512
+      timeout = 60
+      env_vars = {
+        DATABASE_URL           = var.database_url
+        APPSYNC_ENDPOINT       = var.appsync_endpoint
+        IDEMPOTENCY_TABLE_NAME = var.idempotency_table_name
+      }
+      sqs_trigger = var.checkin_handler_queue_arn
+    }
+  }
+
+  # Workers only — have SQS event source mappings
+  workers = { for k, v in local.lambdas : k => v if v.sqs_trigger != null }
+}
+
+# ─── ECR Repositories ─────────────────────────────────────────────────────────
+
+resource "aws_ecr_repository" "lambda" {
+  for_each             = local.lambdas
+  name                 = "fluxion-${var.environment}-${each.key}"
+  image_tag_mutability = "MUTABLE"
+  force_delete         = true
+}
+
+# ─── IAM Roles ────────────────────────────────────────────────────────────────
+
+data "aws_iam_policy_document" "lambda_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "lambda" {
+  for_each           = local.lambdas
+  name               = "fluxion-${var.environment}-${each.key}-role"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
+}
+
+# Base policy: CloudWatch Logs + VPC access
+resource "aws_iam_role_policy_attachment" "vpc_access" {
+  for_each   = local.lambdas
+  role       = aws_iam_role.lambda[each.key].name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+}
+
+# SQS receive/delete for workers
+resource "aws_iam_role_policy" "sqs_consume" {
+  for_each = local.workers
+  name     = "sqs-consume"
+  role     = aws_iam_role.lambda[each.key].name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "sqs:ReceiveMessage",
+        "sqs:DeleteMessage",
+        "sqs:GetQueueAttributes",
+      ]
+      Resource = each.value.sqs_trigger
+    }]
+  })
+}
+
+# SQS send for resolvers that enqueue (action_resolver, upload_resolver)
+resource "aws_iam_role_policy" "sqs_send_action" {
+  name = "sqs-send"
+  role = aws_iam_role.lambda["action_resolver"].name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["sqs:SendMessage"]
+      Resource = var.action_trigger_queue_arn
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "sqs_send_upload" {
+  name = "sqs-send"
+  role = aws_iam_role.lambda["upload_resolver"].name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["sqs:SendMessage"]
+      Resource = var.upload_processor_queue_arn
+    }]
+  })
+}
+
+# SNS publish for action_trigger
+resource "aws_iam_role_policy" "sns_publish" {
+  name = "sns-publish"
+  role = aws_iam_role.lambda["action_trigger"].name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["sns:Publish"]
+      Resource = var.command_sns_topic_arn
+    }]
+  })
+}
+
+# DynamoDB idempotency for action_trigger + checkin_handler
+resource "aws_iam_role_policy" "dynamodb_idempotency" {
+  for_each = toset(["action_trigger", "checkin_handler"])
+  name     = "dynamodb-idempotency"
+  role     = aws_iam_role.lambda[each.key].name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "dynamodb:PutItem",
+        "dynamodb:GetItem",
+        "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem",
+      ]
+      Resource = var.idempotency_table_arn
+    }]
+  })
+}
+
+# AppSync invoke for checkin_handler
+resource "aws_iam_role_policy" "appsync_invoke" {
+  name = "appsync-invoke"
+  role = aws_iam_role.lambda["checkin_handler"].name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["appsync:GraphQL"]
+      Resource = "${var.appsync_api_arn}/*"
+    }]
+  })
+}
+
+# ─── Lambda Functions ─────────────────────────────────────────────────────────
+
+resource "aws_lambda_function" "main" {
+  for_each      = local.lambdas
+  function_name = "fluxion-${var.environment}-${each.key}"
+  package_type  = "Image"
+  image_uri     = "${aws_ecr_repository.lambda[each.key].repository_url}:latest"
+  role          = aws_iam_role.lambda[each.key].arn
+  memory_size   = each.value.memory
+  timeout       = each.value.timeout
+
+  environment {
+    variables = each.value.env_vars
+  }
+
+  vpc_config {
+    subnet_ids         = var.private_subnet_ids
+    security_group_ids = [var.lambda_sg_id]
+  }
+
+  # Ignore image_uri changes — CI/CD updates the image
+  lifecycle {
+    ignore_changes = [image_uri]
+  }
+}
+
+# ─── SQS Event Source Mappings (workers only) ─────────────────────────────────
+
+resource "aws_lambda_event_source_mapping" "sqs" {
+  for_each         = local.workers
+  event_source_arn = each.value.sqs_trigger
+  function_name    = aws_lambda_function.main[each.key].arn
+  batch_size       = 10
+  enabled          = true
+
+  function_response_types = ["ReportBatchItemFailures"]
+}

--- a/fluxion-backend/infra/modules/compute/outputs.tf
+++ b/fluxion-backend/infra/modules/compute/outputs.tf
@@ -1,2 +1,49 @@
-# Lambda ARNs, ECR repo URLs
-# Implementation: issues #34, #35, #36
+# Lambda ARNs — needed by API module for AppSync resolver datasources
+output "device_resolver_arn" {
+  value = aws_lambda_function.main["device_resolver"].arn
+}
+
+output "platform_resolver_arn" {
+  value = aws_lambda_function.main["platform_resolver"].arn
+}
+
+output "user_resolver_arn" {
+  value = aws_lambda_function.main["user_resolver"].arn
+}
+
+output "action_resolver_arn" {
+  value = aws_lambda_function.main["action_resolver"].arn
+}
+
+output "upload_resolver_arn" {
+  value = aws_lambda_function.main["upload_resolver"].arn
+}
+
+output "chat_resolver_arn" {
+  value = aws_lambda_function.main["chat_resolver"].arn
+}
+
+# Lambda invoke ARNs — needed for AppSync datasource invoke permissions
+output "device_resolver_invoke_arn" {
+  value = aws_lambda_function.main["device_resolver"].invoke_arn
+}
+
+output "platform_resolver_invoke_arn" {
+  value = aws_lambda_function.main["platform_resolver"].invoke_arn
+}
+
+output "user_resolver_invoke_arn" {
+  value = aws_lambda_function.main["user_resolver"].invoke_arn
+}
+
+output "action_resolver_invoke_arn" {
+  value = aws_lambda_function.main["action_resolver"].invoke_arn
+}
+
+output "upload_resolver_invoke_arn" {
+  value = aws_lambda_function.main["upload_resolver"].invoke_arn
+}
+
+output "chat_resolver_invoke_arn" {
+  value = aws_lambda_function.main["chat_resolver"].invoke_arn
+}

--- a/fluxion-backend/infra/modules/compute/variables.tf
+++ b/fluxion-backend/infra/modules/compute/variables.tf
@@ -2,3 +2,72 @@ variable "environment" {
   type    = string
   default = "dev"
 }
+
+variable "region" {
+  type    = string
+  default = "ap-southeast-1"
+}
+
+# Network
+variable "private_subnet_ids" {
+  type = list(string)
+}
+
+variable "lambda_sg_id" {
+  type = string
+}
+
+# Database
+variable "db_secret_arn" {
+  type = string
+}
+
+variable "database_url" {
+  type      = string
+  sensitive = true
+}
+
+# Messaging — queue URLs (for Lambda env vars)
+variable "action_trigger_queue_url" {
+  type = string
+}
+
+variable "upload_processor_queue_url" {
+  type = string
+}
+
+# Messaging — queue ARNs (for IAM + event source mappings)
+variable "action_trigger_queue_arn" {
+  type = string
+}
+
+variable "upload_processor_queue_arn" {
+  type = string
+}
+
+variable "checkin_handler_queue_arn" {
+  type = string
+}
+
+# SNS
+variable "command_sns_topic_arn" {
+  type = string
+}
+
+# AppSync
+variable "appsync_endpoint" {
+  type = string
+}
+
+variable "appsync_api_arn" {
+  type = string
+}
+
+# DynamoDB
+variable "idempotency_table_name" {
+  type = string
+}
+
+variable "idempotency_table_arn" {
+  type = string
+}

--- a/fluxion-backend/infra/modules/messaging/main.tf
+++ b/fluxion-backend/infra/modules/messaging/main.tf
@@ -33,3 +33,45 @@ resource "aws_sqs_queue" "upload_processor" {
     maxReceiveCount     = var.dlq_max_receive_count
   })
 }
+
+# ─── Checkin Handler Queue ────────────────────────────────────────────────────
+
+resource "aws_sqs_queue" "checkin_handler_dlq" {
+  name                      = "fluxion-${var.environment}-checkin-handler-dlq"
+  message_retention_seconds = var.message_retention_seconds
+}
+
+resource "aws_sqs_queue" "checkin_handler" {
+  name                       = "fluxion-${var.environment}-checkin-handler-sqs"
+  visibility_timeout_seconds = var.visibility_timeout_seconds
+  message_retention_seconds  = var.message_retention_seconds
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.checkin_handler_dlq.arn
+    maxReceiveCount     = var.dlq_max_receive_count
+  })
+}
+
+# ─── Command SNS Topic ───────────────────────────────────────────────────────
+
+resource "aws_sns_topic" "command" {
+  name = "fluxion-${var.environment}-command-sns"
+}
+
+# ─── DynamoDB Idempotency Table ──────────────────────────────────────────────
+
+resource "aws_dynamodb_table" "idempotency" {
+  name         = "fluxion-${var.environment}-idempotency"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "id"
+
+  attribute {
+    name = "id"
+    type = "S"
+  }
+
+  ttl {
+    attribute_name = "expiration"
+    enabled        = true
+  }
+}

--- a/fluxion-backend/infra/modules/messaging/main.tf
+++ b/fluxion-backend/infra/modules/messaging/main.tf
@@ -7,7 +7,7 @@ resource "aws_sqs_queue" "action_trigger_dlq" {
 
 resource "aws_sqs_queue" "action_trigger" {
   name                       = "fluxion-${var.environment}-action-trigger-sqs"
-  visibility_timeout_seconds = var.visibility_timeout_seconds
+  visibility_timeout_seconds = var.worker_visibility_timeout_seconds
   message_retention_seconds  = var.message_retention_seconds
 
   redrive_policy = jsonencode({
@@ -43,7 +43,7 @@ resource "aws_sqs_queue" "checkin_handler_dlq" {
 
 resource "aws_sqs_queue" "checkin_handler" {
   name                       = "fluxion-${var.environment}-checkin-handler-sqs"
-  visibility_timeout_seconds = var.visibility_timeout_seconds
+  visibility_timeout_seconds = var.worker_visibility_timeout_seconds
   message_retention_seconds  = var.message_retention_seconds
 
   redrive_policy = jsonencode({

--- a/fluxion-backend/infra/modules/messaging/outputs.tf
+++ b/fluxion-backend/infra/modules/messaging/outputs.tf
@@ -24,3 +24,27 @@ output "action_trigger_dlq_arn" {
 output "upload_processor_dlq_arn" {
   value = aws_sqs_queue.upload_processor_dlq.arn
 }
+
+output "checkin_handler_queue_url" {
+  value = aws_sqs_queue.checkin_handler.url
+}
+
+output "checkin_handler_queue_arn" {
+  value = aws_sqs_queue.checkin_handler.arn
+}
+
+output "checkin_handler_dlq_arn" {
+  value = aws_sqs_queue.checkin_handler_dlq.arn
+}
+
+output "command_sns_topic_arn" {
+  value = aws_sns_topic.command.arn
+}
+
+output "idempotency_table_name" {
+  value = aws_dynamodb_table.idempotency.name
+}
+
+output "idempotency_table_arn" {
+  value = aws_dynamodb_table.idempotency.arn
+}

--- a/fluxion-backend/infra/modules/messaging/variables.tf
+++ b/fluxion-backend/infra/modules/messaging/variables.tf
@@ -8,6 +8,11 @@ variable "visibility_timeout_seconds" {
   default = 30
 }
 
+variable "worker_visibility_timeout_seconds" {
+  type    = number
+  default = 360 # 6× max Lambda timeout (60s) per AWS recommendation
+}
+
 variable "message_retention_seconds" {
   type    = number
   default = 345600 # 4 days

--- a/fluxion-backend/modules/action_trigger/requirements.txt
+++ b/fluxion-backend/modules/action_trigger/requirements.txt
@@ -1,2 +1,3 @@
 aws-lambda-powertools[all]==3.7.0
 psycopg[binary]==3.2.6
+boto3>=1.35.0

--- a/fluxion-backend/modules/action_trigger/src/config.py
+++ b/fluxion-backend/modules/action_trigger/src/config.py
@@ -1,9 +1,12 @@
 import os
 
+import boto3
 from aws_lambda_powertools import Logger, Tracer
 
 DATABASE_URL = os.environ.get("DATABASE_URL", "")
 SNS_TOPIC_ARN = os.environ.get("SNS_TOPIC_ARN", "")
+IDEMPOTENCY_TABLE_NAME = os.environ.get("IDEMPOTENCY_TABLE_NAME", "")
 
 logger = Logger()
 tracer = Tracer()
+sns_client = boto3.client("sns")

--- a/fluxion-backend/modules/action_trigger/src/const.py
+++ b/fluxion-backend/modules/action_trigger/src/const.py
@@ -1,1 +1,3 @@
 """Constants for action_trigger."""
+
+ACTION_PENDING = "ACTION_PENDING"

--- a/fluxion-backend/modules/action_trigger/src/db.py
+++ b/fluxion-backend/modules/action_trigger/src/db.py
@@ -1,6 +1,81 @@
+"""Database queries for action_trigger. Uses explicit {schema}.table for tenant isolation."""
+
 import psycopg
-from config import DATABASE_URL
+from config import DATABASE_URL, logger
+from const import ACTION_PENDING
+from psycopg.rows import dict_row
 
 
-def get_connection():
-    return psycopg.connect(DATABASE_URL)
+class DBConnection:
+    """Singleton DB connection for action_trigger.
+
+    Uses autocommit=False for transactional writes (insert execution + assign action).
+    """
+
+    _conn: psycopg.Connection | None = None
+
+    @classmethod
+    def _get_conn(cls) -> psycopg.Connection:
+        if cls._conn is None or cls._conn.closed:
+            logger.info("Creating new database connection")
+            cls._conn = psycopg.connect(DATABASE_URL, autocommit=False, row_factory=dict_row)
+        return cls._conn
+
+    @classmethod
+    def create_execution_and_assign(
+        cls,
+        schema_name: str,
+        execution_id: str,
+        command_uuid: str,
+        device_id: str,
+        action_id: str,
+    ) -> None:
+        """Insert action_execution + assign action to device in a single transaction."""
+        conn = cls._get_conn()
+        with conn.transaction():
+            conn.execute(
+                f"""
+                INSERT INTO {schema_name}.action_executions
+                    (id, device_id, action_id, command_uuid, status)
+                VALUES (%(id)s, %(device_id)s, %(action_id)s, %(command_uuid)s, %(status)s)
+                """,
+                {
+                    "id": execution_id,
+                    "device_id": device_id,
+                    "action_id": action_id,
+                    "command_uuid": command_uuid,
+                    "status": ACTION_PENDING,
+                },
+            )
+            conn.execute(
+                f"UPDATE {schema_name}.devices SET assigned_action_id = %(action_id)s WHERE id = %(device_id)s",
+                {"action_id": action_id, "device_id": device_id},
+            )
+
+    @classmethod
+    def get_device_tokens(cls, schema_name: str, device_id: str) -> dict | None:
+        """Get push credentials from device_tokens."""
+        conn = cls._get_conn()
+        return conn.execute(
+            f"SELECT push_token, push_magic, topic FROM {schema_name}.device_tokens WHERE device_id = %(device_id)s",
+            {"device_id": device_id},
+        ).fetchone()
+
+    @classmethod
+    def get_action_details(cls, schema_name: str, action_id: str) -> dict | None:
+        """Get action name, type, and configuration."""
+        conn = cls._get_conn()
+        return conn.execute(
+            f"SELECT id, name, action_type_id, configuration FROM {schema_name}.actions WHERE id = %(action_id)s",
+            {"action_id": action_id},
+        ).fetchone()
+
+    @classmethod
+    def get_device_udid(cls, schema_name: str, device_id: str) -> str | None:
+        """Get device UDID from device_informations."""
+        conn = cls._get_conn()
+        row = conn.execute(
+            f"SELECT udid FROM {schema_name}.device_informations WHERE device_id = %(device_id)s",
+            {"device_id": device_id},
+        ).fetchone()
+        return row["udid"] if row else None

--- a/fluxion-backend/modules/action_trigger/src/db.py
+++ b/fluxion-backend/modules/action_trigger/src/db.py
@@ -30,7 +30,12 @@ class DBConnection:
         device_id: str,
         action_id: str,
     ) -> None:
-        """Insert action_execution + assign action to device in a single transaction."""
+        """Insert action_execution + assign action to device in a single transaction.
+
+        Uses ON CONFLICT DO NOTHING for idempotent SQS retries — if the execution
+        already exists (from a previous attempt that failed after DB commit but before
+        SNS publish), the INSERT is a no-op and the handler proceeds to publish.
+        """
         conn = cls._get_conn()
         with conn.transaction():
             conn.execute(
@@ -38,6 +43,7 @@ class DBConnection:
                 INSERT INTO {schema_name}.action_executions
                     (id, device_id, action_id, command_uuid, status)
                 VALUES (%(id)s, %(device_id)s, %(action_id)s, %(command_uuid)s, %(status)s)
+                ON CONFLICT (id) DO NOTHING
                 """,
                 {
                     "id": execution_id,

--- a/fluxion-backend/modules/action_trigger/src/exceptions.py
+++ b/fluxion-backend/modules/action_trigger/src/exceptions.py
@@ -1,2 +1,14 @@
+"""Custom exceptions for action_trigger."""
+
+
 class FluxionError(Exception):
-    """Base exception for this module."""
+    """Base exception with error_type for structured error reporting."""
+
+    def __init__(self, message: str, error_type: str = "INTERNAL_ERROR"):
+        super().__init__(message)
+        self.error_type = error_type
+
+
+class DeviceTokensNotFoundError(FluxionError):
+    def __init__(self, device_id: str):
+        super().__init__(f"Device tokens not found for {device_id}", "DEVICE_TOKENS_NOT_FOUND")

--- a/fluxion-backend/modules/action_trigger/src/handler.py
+++ b/fluxion-backend/modules/action_trigger/src/handler.py
@@ -1,9 +1,70 @@
+"""Lambda handler for action_trigger — SQS-triggered execution creation + SNS publish."""
+
+import json
+
 from aws_lambda_powertools.utilities.typing import LambdaContext
-from config import logger, tracer
+from config import SNS_TOPIC_ARN, logger, tracer
+from db import DBConnection
+from exceptions import DeviceTokensNotFoundError
+from utils import send_sns_message, validate_tenant_id
+
+
+def _process_record(body: dict) -> None:
+    """Process a single SQS record — create execution, assign action, publish command."""
+    tenant = validate_tenant_id(body["tenantId"])
+    device_id = body["deviceId"]
+    action_id = body["actionId"]
+    execution_id = body["executionId"]
+    command_uuid = body["commandUuid"]
+
+    log_ctx = {"execution_id": execution_id, "device_id": device_id, "action_id": action_id}
+
+    # 1. Insert execution + assign action (transactional)
+    logger.info("Creating execution and assigning action", extra=log_ctx)
+    DBConnection.create_execution_and_assign(tenant, execution_id, command_uuid, device_id, action_id)
+
+    # 2. Get push credentials
+    tokens = DBConnection.get_device_tokens(tenant, device_id)
+    if not tokens:
+        raise DeviceTokensNotFoundError(device_id)
+    logger.debug("Device tokens retrieved", extra=log_ctx)
+
+    # 3. Get action details + device UDID
+    action = DBConnection.get_action_details(tenant, action_id)
+    udid = DBConnection.get_device_udid(tenant, device_id)
+    action_name = action["name"] if action else None
+    logger.debug("Action details retrieved", extra={**log_ctx, "action_name": action_name, "udid": udid})
+
+    # 4. Publish command to SNS for OEM processor
+    message_body = {
+        "commandUuid": command_uuid,
+        "deviceUdid": udid,
+        "pushToken": tokens["push_token"].hex() if tokens.get("push_token") else None,
+        "pushMagic": tokens.get("push_magic"),
+        "topic": tokens.get("topic"),
+        "requestType": action["name"] if action else None,
+        "commandPayload": body.get("configuration") or (action.get("configuration") if action else None),
+        "tenantId": tenant,
+    }
+    send_sns_message(SNS_TOPIC_ARN, message_body)
+
+    logger.info("Action triggered — command published to SNS", extra={**log_ctx, "command_uuid": command_uuid})
 
 
 @logger.inject_lambda_context
 @tracer.capture_lambda_handler
 def handler(event: dict, context: LambdaContext) -> dict:
-    """Lambda handler for action_trigger."""
-    raise NotImplementedError
+    """Process SQS messages — create executions and publish MDM commands."""
+    batch_failures = []
+    logger.debug("Event received", extra={"event": event})
+
+    for record in event.get("Records", []):
+        message_id = record["messageId"]
+        try:
+            body = json.loads(record["body"])
+            _process_record(body)
+        except Exception:
+            logger.exception("Failed to process message", extra={"message_id": message_id})
+            batch_failures.append({"itemIdentifier": message_id})
+
+    return {"batchItemFailures": batch_failures}

--- a/fluxion-backend/modules/action_trigger/src/tests/test_handler.py
+++ b/fluxion-backend/modules/action_trigger/src/tests/test_handler.py
@@ -1,5 +1,160 @@
-"""Tests for action_trigger handler."""
+"""Tests for action_trigger handler — mock DB + SNS, test execution creation + command publish."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+# Mock config before importing handler (Lambda Powertools needs env vars)
+with patch.dict(
+    "os.environ",
+    {
+        "POWERTOOLS_SERVICE_NAME": "test",
+        "POWERTOOLS_TRACE_DISABLED": "1",
+        "SNS_TOPIC_ARN": "arn:aws:sns:ap-southeast-1:123456789:test-topic",
+        "AWS_DEFAULT_REGION": "ap-southeast-1",
+    },
+):
+    from db import DBConnection
+    from handler import handler
+
+TENANT = "test_tenant"
+
+MOCK_TOKENS = {
+    "push_token": b"\xab\xcd\xef",
+    "push_magic": "magic-123",
+    "topic": "com.apple.mgmt",
+}
+
+MOCK_ACTION = {
+    "id": "a-001",
+    "name": "Lock",
+    "action_type_id": 1,
+    "configuration": {"key": "value"},
+}
 
 
-def test_placeholder():
-    assert True
+def _make_sqs_event(records: list[dict]) -> dict:
+    return {
+        "Records": [
+            {"messageId": f"msg-{i}", "body": json.dumps(rec)}
+            for i, rec in enumerate(records)
+        ],
+    }
+
+
+def _action_msg(
+    device_id: str = "d-001",
+    action_id: str = "a-001",
+    execution_id: str = "exec-001",
+    command_uuid: str = "cmd-001",
+) -> dict:
+    return {
+        "executionId": execution_id,
+        "commandUuid": command_uuid,
+        "deviceId": device_id,
+        "actionId": action_id,
+        "configuration": None,
+        "tenantId": TENANT,
+    }
+
+
+class TestActionTrigger:
+    @patch("handler.send_sns_message")
+    @patch.object(DBConnection, "get_device_udid")
+    @patch.object(DBConnection, "get_action_details")
+    @patch.object(DBConnection, "get_device_tokens")
+    @patch.object(DBConnection, "create_execution_and_assign")
+    def test_happy_path(self, mock_create, mock_tokens, mock_action, mock_udid, mock_sns):
+        """Record processed → execution created, action assigned, SNS published."""
+        mock_tokens.return_value = MOCK_TOKENS
+        mock_action.return_value = MOCK_ACTION
+        mock_udid.return_value = "UDID-123"
+
+        event = _make_sqs_event([_action_msg()])
+        result = handler(event, MagicMock())
+
+        assert result["batchItemFailures"] == []
+        mock_create.assert_called_once_with(TENANT, "exec-001", "cmd-001", "d-001", "a-001")
+        mock_sns.assert_called_once()
+
+        # Verify SNS payload
+        sns_body = mock_sns.call_args[0][1]
+        assert sns_body["commandUuid"] == "cmd-001"
+        assert sns_body["deviceUdid"] == "UDID-123"
+        assert sns_body["pushToken"] == "abcdef"
+        assert sns_body["pushMagic"] == "magic-123"
+        assert sns_body["topic"] == "com.apple.mgmt"
+        assert sns_body["requestType"] == "Lock"
+        assert sns_body["tenantId"] == TENANT
+
+    @patch("handler.send_sns_message")
+    @patch.object(DBConnection, "get_device_tokens")
+    @patch.object(DBConnection, "create_execution_and_assign")
+    def test_device_tokens_not_found(self, mock_create, mock_tokens, mock_sns):
+        """No device tokens → error → batch failure."""
+        mock_tokens.return_value = None
+
+        event = _make_sqs_event([_action_msg()])
+        result = handler(event, MagicMock())
+
+        assert len(result["batchItemFailures"]) == 1
+        assert result["batchItemFailures"][0]["itemIdentifier"] == "msg-0"
+        mock_sns.assert_not_called()
+
+    @patch("handler.send_sns_message")
+    @patch.object(DBConnection, "get_device_udid")
+    @patch.object(DBConnection, "get_action_details")
+    @patch.object(DBConnection, "get_device_tokens")
+    @patch.object(DBConnection, "create_execution_and_assign")
+    def test_multiple_records(self, mock_create, mock_tokens, mock_action, mock_udid, mock_sns):
+        """2 records → both processed, SNS called 2x."""
+        mock_tokens.return_value = MOCK_TOKENS
+        mock_action.return_value = MOCK_ACTION
+        mock_udid.return_value = "UDID-123"
+
+        event = _make_sqs_event([
+            _action_msg(device_id="d-001", execution_id="exec-1"),
+            _action_msg(device_id="d-002", execution_id="exec-2"),
+        ])
+        result = handler(event, MagicMock())
+
+        assert result["batchItemFailures"] == []
+        assert mock_sns.call_count == 2
+
+    @patch("handler.send_sns_message")
+    @patch.object(DBConnection, "get_device_tokens")
+    @patch.object(DBConnection, "create_execution_and_assign")
+    def test_partial_failure(self, mock_create, mock_tokens, mock_sns):
+        """2 records, second has no tokens → 1 batch failure."""
+        mock_tokens.side_effect = [MOCK_TOKENS, None]
+
+        # First record needs full mocks for SNS path
+        with patch.object(DBConnection, "get_action_details", return_value=MOCK_ACTION), \
+             patch.object(DBConnection, "get_device_udid", return_value="UDID-1"):
+            event = _make_sqs_event([
+                _action_msg(device_id="d-001", execution_id="exec-1"),
+                _action_msg(device_id="d-002", execution_id="exec-2"),
+            ])
+            result = handler(event, MagicMock())
+
+        assert len(result["batchItemFailures"]) == 1
+        assert result["batchItemFailures"][0]["itemIdentifier"] == "msg-1"
+        assert mock_sns.call_count == 1
+
+    @patch("handler.send_sns_message")
+    @patch.object(DBConnection, "get_device_udid")
+    @patch.object(DBConnection, "get_action_details")
+    @patch.object(DBConnection, "get_device_tokens")
+    @patch.object(DBConnection, "create_execution_and_assign")
+    def test_configuration_from_message(self, mock_create, mock_tokens, mock_action, mock_udid, mock_sns):
+        """Configuration from message body takes priority over action configuration."""
+        mock_tokens.return_value = MOCK_TOKENS
+        mock_action.return_value = MOCK_ACTION
+        mock_udid.return_value = "UDID-123"
+
+        msg = _action_msg()
+        msg["configuration"] = '{"custom": "config"}'
+        event = _make_sqs_event([msg])
+        handler(event, MagicMock())
+
+        sns_body = mock_sns.call_args[0][1]
+        assert sns_body["commandPayload"] == '{"custom": "config"}'

--- a/fluxion-backend/modules/action_trigger/src/utils.py
+++ b/fluxion-backend/modules/action_trigger/src/utils.py
@@ -1,1 +1,18 @@
 """Utility functions for action_trigger."""
+
+import json
+import re
+
+from config import sns_client
+
+
+def send_sns_message(topic_arn: str, message_body: dict) -> None:
+    """Publish a JSON message to an SNS topic."""
+    sns_client.publish(TopicArn=topic_arn, Message=json.dumps(message_body))
+
+
+def validate_tenant_id(tenant_id: str) -> str:
+    """Validate tenant_id format (alphanumeric + underscore only) to prevent SQL injection."""
+    if not re.match(r"^[a-zA-Z0-9_]+$", tenant_id):
+        raise ValueError("Invalid tenant_id format")
+    return tenant_id

--- a/fluxion-backend/modules/checkin_handler/requirements.txt
+++ b/fluxion-backend/modules/checkin_handler/requirements.txt
@@ -1,2 +1,3 @@
 aws-lambda-powertools[all]==3.7.0
 psycopg[binary]==3.2.6
+boto3>=1.35.0

--- a/fluxion-backend/modules/checkin_handler/src/config.py
+++ b/fluxion-backend/modules/checkin_handler/src/config.py
@@ -4,7 +4,7 @@ from aws_lambda_powertools import Logger, Tracer
 
 DATABASE_URL = os.environ.get("DATABASE_URL", "")
 APPSYNC_ENDPOINT = os.environ.get("APPSYNC_ENDPOINT", "")
-APPSYNC_API_KEY = os.environ.get("APPSYNC_API_KEY", "")
+IDEMPOTENCY_TABLE_NAME = os.environ.get("IDEMPOTENCY_TABLE_NAME", "")
 
 logger = Logger()
 tracer = Tracer()

--- a/fluxion-backend/modules/checkin_handler/src/const.py
+++ b/fluxion-backend/modules/checkin_handler/src/const.py
@@ -1,1 +1,15 @@
 """Constants for checkin_handler."""
+
+# Event types from OEM processor
+EVENT_DEVICE_TOKEN_UPDATE = "DEVICE_TOKEN_UPDATE"
+EVENT_DEVICE_RELEASED = "DEVICE_RELEASED"
+EVENT_ACTION_COMPLETED = "ACTION_COMPLETED"
+EVENT_ACTION_FAILED = "ACTION_FAILED"
+
+# Action execution statuses
+ACTION_COMPLETED = "ACTION_COMPLETED"
+ACTION_FAILED = "ACTION_FAILED"
+
+# Released state — matches seed data (state_id=6 Released, policy_id=6)
+RELEASED_STATE_ID = 6
+RELEASED_POLICY_ID = 6

--- a/fluxion-backend/modules/checkin_handler/src/db.py
+++ b/fluxion-backend/modules/checkin_handler/src/db.py
@@ -4,6 +4,9 @@ import psycopg
 from config import DATABASE_URL, logger
 from psycopg.rows import dict_row
 
+# Sentinel for "don't update this column" in update_device
+_SKIP = object()
+
 
 class DBConnection:
     """Singleton DB connection for checkin_handler.
@@ -64,11 +67,11 @@ class DBConnection:
         device_id: str,
         state_id: int | None = None,
         current_policy_id: int | None = None,
-        assigned_action_id: str | None = "SKIP",
+        assigned_action_id=_SKIP,
     ) -> None:
         """UPDATE devices with dynamic SET clauses.
 
-        Pass assigned_action_id=None to clear it, "SKIP" (default) to leave unchanged.
+        Pass assigned_action_id=None to clear it, _SKIP (default) to leave unchanged.
         """
         conn = cls._get_conn()
         sets: list[str] = []
@@ -80,7 +83,7 @@ class DBConnection:
         if current_policy_id is not None:
             sets.append("current_policy_id = %(policy_id)s")
             params["policy_id"] = current_policy_id
-        if assigned_action_id != "SKIP":
+        if assigned_action_id is not _SKIP:
             sets.append("assigned_action_id = %(action_id)s")
             params["action_id"] = assigned_action_id
 

--- a/fluxion-backend/modules/checkin_handler/src/db.py
+++ b/fluxion-backend/modules/checkin_handler/src/db.py
@@ -1,6 +1,140 @@
+"""Database queries for checkin_handler. Uses explicit {schema}.table for tenant isolation."""
+
 import psycopg
-from config import DATABASE_URL
+from config import DATABASE_URL, logger
+from psycopg.rows import dict_row
 
 
-def get_connection():
-    return psycopg.connect(DATABASE_URL)
+class DBConnection:
+    """Singleton DB connection for checkin_handler.
+
+    4 generic functions covering all event types:
+    - update_device_token: UPSERT device_tokens
+    - update_device: UPDATE devices with dynamic SET clauses
+    - update_action_execution: UPDATE action_executions by command_uuid
+    - insert_milestone: INSERT milestones
+    """
+
+    _conn: psycopg.Connection | None = None
+
+    @classmethod
+    def _get_conn(cls) -> psycopg.Connection:
+        if cls._conn is None or cls._conn.closed:
+            logger.info("Creating new database connection")
+            cls._conn = psycopg.connect(DATABASE_URL, autocommit=False, row_factory=dict_row)
+        return cls._conn
+
+    @classmethod
+    def update_device_token(
+        cls,
+        schema_name: str,
+        device_id: str,
+        push_token: bytes | None,
+        push_magic: str | None,
+        topic: str | None,
+        unlock_token: bytes | None,
+    ) -> None:
+        """UPSERT device_tokens — ON CONFLICT (device_id) DO UPDATE."""
+        conn = cls._get_conn()
+        with conn.transaction():
+            conn.execute(
+                f"""
+                INSERT INTO {schema_name}.device_tokens (device_id, push_token, push_magic, topic, unlock_token)
+                VALUES (%(device_id)s, %(push_token)s, %(push_magic)s, %(topic)s, %(unlock_token)s)
+                ON CONFLICT (device_id) DO UPDATE SET
+                    push_token = EXCLUDED.push_token,
+                    push_magic = EXCLUDED.push_magic,
+                    topic = EXCLUDED.topic,
+                    unlock_token = EXCLUDED.unlock_token,
+                    updated_at = NOW()
+                """,
+                {
+                    "device_id": device_id,
+                    "push_token": push_token,
+                    "push_magic": push_magic,
+                    "topic": topic,
+                    "unlock_token": unlock_token,
+                },
+            )
+
+    @classmethod
+    def update_device(
+        cls,
+        schema_name: str,
+        device_id: str,
+        state_id: int | None = None,
+        current_policy_id: int | None = None,
+        assigned_action_id: str | None = "SKIP",
+    ) -> None:
+        """UPDATE devices with dynamic SET clauses.
+
+        Pass assigned_action_id=None to clear it, "SKIP" (default) to leave unchanged.
+        """
+        conn = cls._get_conn()
+        sets: list[str] = []
+        params: dict = {"device_id": device_id}
+
+        if state_id is not None:
+            sets.append("state_id = %(state_id)s")
+            params["state_id"] = state_id
+        if current_policy_id is not None:
+            sets.append("current_policy_id = %(policy_id)s")
+            params["policy_id"] = current_policy_id
+        if assigned_action_id != "SKIP":
+            sets.append("assigned_action_id = %(action_id)s")
+            params["action_id"] = assigned_action_id
+
+        if not sets:
+            return
+
+        with conn.transaction():
+            conn.execute(
+                f"UPDATE {schema_name}.devices SET {', '.join(sets)} WHERE id = %(device_id)s",
+                params,
+            )
+
+    @classmethod
+    def update_action_execution(
+        cls, schema_name: str, command_uuid: str, status: str
+    ) -> dict | None:
+        """UPDATE action_executions by command_uuid. Returns execution row."""
+        conn = cls._get_conn()
+        with conn.transaction():
+            return conn.execute(
+                f"""
+                UPDATE {schema_name}.action_executions
+                SET status = %(status)s
+                WHERE command_uuid = %(command_uuid)s
+                RETURNING id, device_id, action_id
+                """,
+                {"status": status, "command_uuid": command_uuid},
+            ).fetchone()
+
+    @classmethod
+    def insert_milestone(
+        cls, schema_name: str, device_id: str, action_id: str, policy_id: int
+    ) -> None:
+        """INSERT milestones row for device history timeline."""
+        conn = cls._get_conn()
+        with conn.transaction():
+            conn.execute(
+                f"""
+                INSERT INTO {schema_name}.milestones (device_id, assigned_action_id, policy_id)
+                VALUES (%(device_id)s, %(action_id)s, %(policy_id)s)
+                """,
+                {"device_id": device_id, "action_id": action_id, "policy_id": policy_id},
+            )
+
+    @classmethod
+    def get_action_policy(cls, schema_name: str, action_id: str) -> dict | None:
+        """Get action's apply_policy with state_id. Returns {apply_policy_id, state_id}."""
+        conn = cls._get_conn()
+        return conn.execute(
+            f"""
+            SELECT a.apply_policy_id, p.state_id
+            FROM {schema_name}.actions a
+            JOIN {schema_name}.policies p ON a.apply_policy_id = p.id
+            WHERE a.id = %(action_id)s
+            """,
+            {"action_id": action_id},
+        ).fetchone()

--- a/fluxion-backend/modules/checkin_handler/src/exceptions.py
+++ b/fluxion-backend/modules/checkin_handler/src/exceptions.py
@@ -1,2 +1,19 @@
+"""Custom exceptions for checkin_handler."""
+
+
 class FluxionError(Exception):
-    """Base exception for this module."""
+    """Base exception with error_type for structured error reporting."""
+
+    def __init__(self, message: str, error_type: str = "INTERNAL_ERROR"):
+        super().__init__(message)
+        self.error_type = error_type
+
+
+class ExecutionNotFoundError(FluxionError):
+    def __init__(self, command_uuid: str):
+        super().__init__(f"Execution not found for command_uuid {command_uuid}", "EXECUTION_NOT_FOUND")
+
+
+class UnknownEventTypeError(FluxionError):
+    def __init__(self, event_type: str):
+        super().__init__(f"Unknown event type: {event_type}", "UNKNOWN_EVENT_TYPE")

--- a/fluxion-backend/modules/checkin_handler/src/handler.py
+++ b/fluxion-backend/modules/checkin_handler/src/handler.py
@@ -1,9 +1,177 @@
+"""Lambda handler for checkin_handler — SQS-triggered OEM event processing."""
+
+import json
+
 from aws_lambda_powertools.utilities.typing import LambdaContext
 from config import logger, tracer
+from const import (
+    ACTION_COMPLETED,
+    ACTION_FAILED,
+    EVENT_ACTION_COMPLETED,
+    EVENT_ACTION_FAILED,
+    EVENT_DEVICE_RELEASED,
+    EVENT_DEVICE_TOKEN_UPDATE,
+    RELEASED_POLICY_ID,
+    RELEASED_STATE_ID,
+)
+from db import DBConnection
+from exceptions import ExecutionNotFoundError, UnknownEventTypeError
+from utils import call_appsync_mutation, validate_tenant_id
+
+# GraphQL mutations for AppSync subscriptions
+NOTIFY_DEVICE_STATE = """
+    mutation NotifyDeviceStateChanged($deviceId: ID!, $stateId: Int!, $currentPolicyId: Int!) {
+        notifyDeviceStateChanged(deviceId: $deviceId, stateId: $stateId, currentPolicyId: $currentPolicyId) { id }
+    }
+"""
+
+NOTIFY_EXECUTION_UPDATED = """
+    mutation NotifyActionExecutionUpdated($deviceId: ID!, $executionId: ID!, $status: ActionStatus!) {
+        notifyActionExecutionUpdated(deviceId: $deviceId, executionId: $executionId, status: $status) { id }
+    }
+"""
+
+
+def _handle_token_update(tenant: str, device_id: str, payload: dict) -> None:
+    """UPSERT device tokens from OEM check-in."""
+    push_token = bytes.fromhex(payload["pushToken"]) if payload.get("pushToken") else None
+    unlock_token = bytes.fromhex(payload["unlockToken"]) if payload.get("unlockToken") else None
+
+    DBConnection.update_device_token(
+        schema_name=tenant,
+        device_id=device_id,
+        push_token=push_token,
+        push_magic=payload.get("pushMagic"),
+        topic=payload.get("topic"),
+        unlock_token=unlock_token,
+    )
+    logger.info("Device tokens updated", extra={"device_id": device_id})
+
+
+def _handle_device_released(tenant: str, device_id: str, payload: dict) -> None:
+    """Release device — update state and notify subscribers."""
+    DBConnection.update_device(
+        tenant, device_id,
+        state_id=RELEASED_STATE_ID,
+        current_policy_id=RELEASED_POLICY_ID,
+        assigned_action_id=None,
+    )
+    logger.info("Device released", extra={"device_id": device_id})
+
+    call_appsync_mutation(NOTIFY_DEVICE_STATE, {
+        "deviceId": device_id,
+        "stateId": RELEASED_STATE_ID,
+        "currentPolicyId": RELEASED_POLICY_ID,
+    })
+
+
+def _handle_action_completed(tenant: str, device_id: str, payload: dict) -> None:
+    """Complete action — update execution, apply policy, create milestone, notify."""
+    command_uuid = payload["commandUuid"]
+
+    # 1. Mark execution as completed
+    execution = DBConnection.update_action_execution(tenant, command_uuid, ACTION_COMPLETED)
+    if not execution:
+        raise ExecutionNotFoundError(command_uuid)
+
+    execution_id = str(execution["id"])
+    action_id = str(execution["action_id"])
+    logger.info("Execution completed", extra={"execution_id": execution_id, "command_uuid": command_uuid})
+
+    # 2. Get action's target policy and apply to device
+    policy = DBConnection.get_action_policy(tenant, action_id)
+    if not policy:
+        logger.warning("Action policy not found, skipping state update", extra={"action_id": action_id})
+        return
+
+    state_id = policy["state_id"]
+    policy_id = policy["apply_policy_id"]
+
+    DBConnection.update_device(
+        tenant, device_id,
+        state_id=state_id,
+        current_policy_id=policy_id,
+        assigned_action_id=None,
+    )
+
+    # 3. Record milestone for device history
+    DBConnection.insert_milestone(tenant, device_id, action_id, policy_id)
+
+    # 4. Notify subscribers
+    call_appsync_mutation(NOTIFY_DEVICE_STATE, {
+        "deviceId": device_id,
+        "stateId": state_id,
+        "currentPolicyId": policy_id,
+    })
+    call_appsync_mutation(NOTIFY_EXECUTION_UPDATED, {
+        "deviceId": device_id,
+        "executionId": execution_id,
+        "status": ACTION_COMPLETED,
+    })
+
+
+def _handle_action_failed(tenant: str, device_id: str, payload: dict) -> None:
+    """Fail action — update execution, clear assigned action, notify."""
+    command_uuid = payload["commandUuid"]
+
+    # 1. Mark execution as failed
+    execution = DBConnection.update_action_execution(tenant, command_uuid, ACTION_FAILED)
+    if not execution:
+        raise ExecutionNotFoundError(command_uuid)
+
+    execution_id = str(execution["id"])
+    logger.info("Execution failed", extra={
+        "execution_id": execution_id,
+        "command_uuid": command_uuid,
+        "error": payload.get("errorMessage"),
+    })
+
+    # 2. Clear assigned action on device
+    DBConnection.update_device(tenant, device_id, assigned_action_id=None)
+
+    # 3. Notify subscribers (execution update only, not device state)
+    call_appsync_mutation(NOTIFY_EXECUTION_UPDATED, {
+        "deviceId": device_id,
+        "executionId": execution_id,
+        "status": ACTION_FAILED,
+    })
+
+
+EVENT_HANDLERS = {
+    EVENT_DEVICE_TOKEN_UPDATE: _handle_token_update,
+    EVENT_DEVICE_RELEASED: _handle_device_released,
+    EVENT_ACTION_COMPLETED: _handle_action_completed,
+    EVENT_ACTION_FAILED: _handle_action_failed,
+}
 
 
 @logger.inject_lambda_context
 @tracer.capture_lambda_handler
 def handler(event: dict, context: LambdaContext) -> dict:
-    """Lambda handler for checkin_handler."""
-    raise NotImplementedError
+    """Process SQS messages — dispatch to event-type-specific handlers."""
+    batch_failures = []
+    logger.debug("Event received", extra={"record_count": len(event.get("Records", []))})
+
+    for record in event.get("Records", []):
+        message_id = record["messageId"]
+        try:
+            body = json.loads(record["body"])
+            tenant = validate_tenant_id(body["tenantId"])
+            event_type = body["eventType"]
+            device_id = body["deviceId"]
+            payload = body.get("payload", {})
+
+            handler_fn = EVENT_HANDLERS.get(event_type)
+            if not handler_fn:
+                raise UnknownEventTypeError(event_type)
+
+            logger.info("Processing event", extra={
+                "event_type": event_type, "device_id": device_id, "message_id": message_id,
+            })
+            handler_fn(tenant, device_id, payload)
+
+        except Exception:
+            logger.exception("Failed to process message", extra={"message_id": message_id})
+            batch_failures.append({"itemIdentifier": message_id})
+
+    return {"batchItemFailures": batch_failures}

--- a/fluxion-backend/modules/checkin_handler/src/handler.py
+++ b/fluxion-backend/modules/checkin_handler/src/handler.py
@@ -78,7 +78,14 @@ def _handle_action_completed(tenant: str, device_id: str, payload: dict) -> None
     action_id = str(execution["action_id"])
     logger.info("Execution completed", extra={"execution_id": execution_id, "command_uuid": command_uuid})
 
-    # 2. Get action's target policy and apply to device
+    # 2. Always notify execution update (even if policy lookup fails below)
+    call_appsync_mutation(NOTIFY_EXECUTION_UPDATED, {
+        "deviceId": device_id,
+        "executionId": execution_id,
+        "status": ACTION_COMPLETED,
+    })
+
+    # 3. Get action's target policy and apply to device
     policy = DBConnection.get_action_policy(tenant, action_id)
     if not policy:
         logger.warning("Action policy not found, skipping state update", extra={"action_id": action_id})
@@ -94,19 +101,14 @@ def _handle_action_completed(tenant: str, device_id: str, payload: dict) -> None
         assigned_action_id=None,
     )
 
-    # 3. Record milestone for device history
+    # 4. Record milestone for device history
     DBConnection.insert_milestone(tenant, device_id, action_id, policy_id)
 
-    # 4. Notify subscribers
+    # 5. Notify device state change
     call_appsync_mutation(NOTIFY_DEVICE_STATE, {
         "deviceId": device_id,
         "stateId": state_id,
         "currentPolicyId": policy_id,
-    })
-    call_appsync_mutation(NOTIFY_EXECUTION_UPDATED, {
-        "deviceId": device_id,
-        "executionId": execution_id,
-        "status": ACTION_COMPLETED,
     })
 
 

--- a/fluxion-backend/modules/checkin_handler/src/tests/test_handler.py
+++ b/fluxion-backend/modules/checkin_handler/src/tests/test_handler.py
@@ -115,14 +115,14 @@ class TestActionCompleted:
         with patch.object(DBConnection, "update_device"), patch.object(DBConnection, "insert_milestone"):
             handler(event, MagicMock())
 
-        # First call: notifyDeviceStateChanged
-        state_vars = mock_appsync.call_args_list[0][0][1]
-        assert state_vars["stateId"] == 3
-        assert state_vars["currentPolicyId"] == 3
-        # Second call: notifyActionExecutionUpdated
-        exec_vars = mock_appsync.call_args_list[1][0][1]
+        # First call: notifyActionExecutionUpdated (fires early, before policy lookup)
+        exec_vars = mock_appsync.call_args_list[0][0][1]
         assert exec_vars["executionId"] == "exec-001"
         assert exec_vars["status"] == "ACTION_COMPLETED"
+        # Second call: notifyDeviceStateChanged
+        state_vars = mock_appsync.call_args_list[1][0][1]
+        assert state_vars["stateId"] == 3
+        assert state_vars["currentPolicyId"] == 3
 
     @patch("handler.call_appsync_mutation")
     @patch.object(DBConnection, "update_action_execution")

--- a/fluxion-backend/modules/checkin_handler/src/tests/test_handler.py
+++ b/fluxion-backend/modules/checkin_handler/src/tests/test_handler.py
@@ -1,5 +1,189 @@
-"""Tests for checkin_handler handler."""
+"""Tests for checkin_handler — mock DB + AppSync, test all 4 event types."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+# Mock config before importing handler (Lambda Powertools needs env vars)
+with patch.dict(
+    "os.environ",
+    {
+        "POWERTOOLS_SERVICE_NAME": "test",
+        "POWERTOOLS_TRACE_DISABLED": "1",
+        "APPSYNC_ENDPOINT": "https://test.appsync-api.ap-southeast-1.amazonaws.com/graphql",
+        "AWS_DEFAULT_REGION": "ap-southeast-1",
+    },
+):
+    from db import DBConnection
+    from handler import handler
 
 
-def test_placeholder():
-    assert True
+def _make_sqs_event(records: list[dict]) -> dict:
+    return {
+        "Records": [
+            {"messageId": f"msg-{i}", "body": json.dumps(rec)}
+            for i, rec in enumerate(records)
+        ],
+    }
+
+
+def _checkin_msg(event_type: str, device_id: str = "d-001", payload: dict | None = None) -> dict:
+    return {
+        "eventType": event_type,
+        "tenantId": "test_tenant",
+        "deviceId": device_id,
+        "payload": payload or {},
+    }
+
+
+MOCK_EXECUTION = {"id": "exec-001", "device_id": "d-001", "action_id": "a-001"}
+MOCK_POLICY = {"apply_policy_id": 3, "state_id": 3}
+
+
+# --- DEVICE_TOKEN_UPDATE ---
+
+class TestTokenUpdate:
+    @patch("handler.call_appsync_mutation")
+    @patch.object(DBConnection, "update_device_token")
+    def test_happy_path(self, mock_upsert, mock_appsync):
+        payload = {"pushToken": "abcdef", "pushMagic": "magic-1", "topic": "com.apple.mgmt", "unlockToken": None}
+        event = _make_sqs_event([_checkin_msg("DEVICE_TOKEN_UPDATE", payload=payload)])
+        result = handler(event, MagicMock())
+
+        assert result["batchItemFailures"] == []
+        mock_upsert.assert_called_once()
+        call_kwargs = mock_upsert.call_args.kwargs
+        assert call_kwargs["push_token"] == bytes.fromhex("abcdef")
+        assert call_kwargs["push_magic"] == "magic-1"
+        mock_appsync.assert_not_called()
+
+
+# --- DEVICE_RELEASED ---
+
+class TestDeviceReleased:
+    @patch("handler.call_appsync_mutation")
+    @patch.object(DBConnection, "update_device")
+    def test_happy_path(self, mock_update, mock_appsync):
+        event = _make_sqs_event([_checkin_msg("DEVICE_RELEASED", payload={"udid": "UD-001"})])
+        result = handler(event, MagicMock())
+
+        assert result["batchItemFailures"] == []
+        mock_update.assert_called_once_with(
+            "test_tenant", "d-001", state_id=6, current_policy_id=6, assigned_action_id=None,
+        )
+        mock_appsync.assert_called_once()
+        variables = mock_appsync.call_args[0][1]
+        assert variables["deviceId"] == "d-001"
+        assert variables["stateId"] == 6
+        assert variables["currentPolicyId"] == 6
+
+
+# --- ACTION_COMPLETED ---
+
+class TestActionCompleted:
+    @patch("handler.call_appsync_mutation")
+    @patch.object(DBConnection, "insert_milestone")
+    @patch.object(DBConnection, "update_device")
+    @patch.object(DBConnection, "get_action_policy")
+    @patch.object(DBConnection, "update_action_execution")
+    def test_happy_path(self, mock_exec, mock_policy, mock_device, mock_milestone, mock_appsync):
+        mock_exec.return_value = MOCK_EXECUTION
+        mock_policy.return_value = MOCK_POLICY
+
+        payload = {"commandUuid": "cmd-001", "resultPayload": None}
+        event = _make_sqs_event([_checkin_msg("ACTION_COMPLETED", payload=payload)])
+        result = handler(event, MagicMock())
+
+        assert result["batchItemFailures"] == []
+        mock_exec.assert_called_once_with("test_tenant", "cmd-001", "ACTION_COMPLETED")
+        mock_policy.assert_called_once_with("test_tenant", "a-001")
+        mock_device.assert_called_once_with(
+            "test_tenant", "d-001", state_id=3, current_policy_id=3, assigned_action_id=None,
+        )
+        mock_milestone.assert_called_once_with("test_tenant", "d-001", "a-001", 3)
+        assert mock_appsync.call_count == 2
+
+    @patch("handler.call_appsync_mutation")
+    @patch.object(DBConnection, "get_action_policy")
+    @patch.object(DBConnection, "update_action_execution")
+    def test_appsync_variables(self, mock_exec, mock_policy, mock_appsync):
+        """Verify correct variables passed to AppSync mutations."""
+        mock_exec.return_value = MOCK_EXECUTION
+        mock_policy.return_value = MOCK_POLICY
+
+        payload = {"commandUuid": "cmd-001"}
+        event = _make_sqs_event([_checkin_msg("ACTION_COMPLETED", payload=payload)])
+        with patch.object(DBConnection, "update_device"), patch.object(DBConnection, "insert_milestone"):
+            handler(event, MagicMock())
+
+        # First call: notifyDeviceStateChanged
+        state_vars = mock_appsync.call_args_list[0][0][1]
+        assert state_vars["stateId"] == 3
+        assert state_vars["currentPolicyId"] == 3
+        # Second call: notifyActionExecutionUpdated
+        exec_vars = mock_appsync.call_args_list[1][0][1]
+        assert exec_vars["executionId"] == "exec-001"
+        assert exec_vars["status"] == "ACTION_COMPLETED"
+
+    @patch("handler.call_appsync_mutation")
+    @patch.object(DBConnection, "update_action_execution")
+    def test_execution_not_found(self, mock_exec, mock_appsync):
+        mock_exec.return_value = None
+
+        payload = {"commandUuid": "unknown-cmd"}
+        event = _make_sqs_event([_checkin_msg("ACTION_COMPLETED", payload=payload)])
+        result = handler(event, MagicMock())
+
+        assert len(result["batchItemFailures"]) == 1
+        mock_appsync.assert_not_called()
+
+
+# --- ACTION_FAILED ---
+
+class TestActionFailed:
+    @patch("handler.call_appsync_mutation")
+    @patch.object(DBConnection, "update_device")
+    @patch.object(DBConnection, "update_action_execution")
+    def test_happy_path(self, mock_exec, mock_device, mock_appsync):
+        mock_exec.return_value = MOCK_EXECUTION
+
+        payload = {"commandUuid": "cmd-001", "errorMessage": "Device unreachable"}
+        event = _make_sqs_event([_checkin_msg("ACTION_FAILED", payload=payload)])
+        result = handler(event, MagicMock())
+
+        assert result["batchItemFailures"] == []
+        mock_exec.assert_called_once_with("test_tenant", "cmd-001", "ACTION_FAILED")
+        mock_device.assert_called_once_with("test_tenant", "d-001", assigned_action_id=None)
+        # Only notifyActionExecutionUpdated (not device state)
+        mock_appsync.assert_called_once()
+        variables = mock_appsync.call_args[0][1]
+        assert variables["status"] == "ACTION_FAILED"
+
+
+# --- General ---
+
+class TestGeneral:
+    def test_unknown_event_type(self):
+        event = _make_sqs_event([_checkin_msg("UNKNOWN_EVENT")])
+        result = handler(event, MagicMock())
+
+        assert len(result["batchItemFailures"]) == 1
+
+    @patch("handler.call_appsync_mutation")
+    @patch.object(DBConnection, "update_device")
+    @patch.object(DBConnection, "update_device_token")
+    def test_mixed_records_partial_failure(self, mock_token, mock_device, mock_appsync):
+        """3 records: token update OK, unknown type fails, release OK."""
+        records = [
+            _checkin_msg("DEVICE_TOKEN_UPDATE", device_id="d-001", payload={
+                "pushToken": "aa", "pushMagic": "m", "topic": "t", "unlockToken": None,
+            }),
+            _checkin_msg("INVALID_TYPE", device_id="d-002"),
+            _checkin_msg("DEVICE_RELEASED", device_id="d-003", payload={"udid": "UD-3"}),
+        ]
+        event = _make_sqs_event(records)
+        result = handler(event, MagicMock())
+
+        assert len(result["batchItemFailures"]) == 1
+        assert result["batchItemFailures"][0]["itemIdentifier"] == "msg-1"
+        mock_token.assert_called_once()
+        mock_device.assert_called_once()

--- a/fluxion-backend/modules/checkin_handler/src/utils.py
+++ b/fluxion-backend/modules/checkin_handler/src/utils.py
@@ -1,1 +1,53 @@
 """Utility functions for checkin_handler."""
+
+import json
+import re
+import urllib.request
+
+import boto3
+from botocore.auth import SigV4Auth
+from botocore.awsrequest import AWSRequest
+from config import APPSYNC_ENDPOINT, logger
+
+_session = boto3.Session()
+_credentials = _session.get_credentials().get_frozen_credentials()
+_region = _session.region_name or "ap-southeast-1"
+
+
+def validate_tenant_id(tenant_id: str) -> str:
+    """Validate tenant_id format (alphanumeric + underscore only) to prevent SQL injection."""
+    if not re.match(r"^[a-zA-Z0-9_]+$", tenant_id):
+        raise ValueError("Invalid tenant_id format")
+    return tenant_id
+
+
+def call_appsync_mutation(query: str, variables: dict) -> dict:
+    """Call AppSync GraphQL mutation with IAM (SigV4) authentication.
+
+    Uses botocore SigV4Auth to sign the HTTP POST request.
+    The Lambda execution role must have appsync:GraphQL permission.
+    """
+    payload = json.dumps({"query": query, "variables": variables}).encode()
+
+    request = AWSRequest(
+        method="POST",
+        url=APPSYNC_ENDPOINT,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+    )
+    SigV4Auth(_credentials, "appsync", _region).add_auth(request)
+
+    req = urllib.request.Request(
+        APPSYNC_ENDPOINT,
+        data=payload,
+        headers=dict(request.headers),
+        method="POST",
+    )
+
+    with urllib.request.urlopen(req) as resp:
+        response_body = json.loads(resp.read())
+
+    if "errors" in response_body:
+        logger.warning("AppSync mutation returned errors", extra={"errors": response_body["errors"]})
+
+    return response_body

--- a/fluxion-backend/modules/checkin_handler/src/utils.py
+++ b/fluxion-backend/modules/checkin_handler/src/utils.py
@@ -10,7 +10,6 @@ from botocore.awsrequest import AWSRequest
 from config import APPSYNC_ENDPOINT, logger
 
 _session = boto3.Session()
-_credentials = _session.get_credentials().get_frozen_credentials()
 _region = _session.region_name or "ap-southeast-1"
 
 
@@ -35,7 +34,9 @@ def call_appsync_mutation(query: str, variables: dict) -> dict:
         data=payload,
         headers={"Content-Type": "application/json"},
     )
-    SigV4Auth(_credentials, "appsync", _region).add_auth(request)
+    # Resolve credentials per-call to handle IAM role rotation on warm containers
+    credentials = _session.get_credentials().get_frozen_credentials()
+    SigV4Auth(credentials, "appsync", _region).add_auth(request)
 
     req = urllib.request.Request(
         APPSYNC_ENDPOINT,

--- a/fluxion-backend/modules/upload_processor/src/const.py
+++ b/fluxion-backend/modules/upload_processor/src/const.py
@@ -1,1 +1,4 @@
 """Constants for upload_processor."""
+
+INITIAL_STATE_ID = 1      # Idle
+INITIAL_POLICY_ID = 1     # Idle policy

--- a/fluxion-backend/modules/upload_processor/src/db.py
+++ b/fluxion-backend/modules/upload_processor/src/db.py
@@ -1,6 +1,86 @@
+"""Database queries for upload_processor. Uses explicit {schema}.table for tenant isolation."""
+
 import psycopg
-from config import DATABASE_URL
+from config import DATABASE_URL, logger
+from const import INITIAL_POLICY_ID, INITIAL_STATE_ID
+from psycopg.rows import dict_row
 
 
-def get_connection():
-    return psycopg.connect(DATABASE_URL)
+class DBConnection:
+    """Singleton DB connection for upload_processor.
+
+    Uses autocommit=False for explicit transaction control — device + device_information
+    must be inserted atomically to avoid orphan rows.
+    """
+
+    _conn: psycopg.Connection | None = None
+
+    @classmethod
+    def _get_conn(cls) -> psycopg.Connection:
+        if cls._conn is None or cls._conn.closed:
+            logger.info("Creating new database connection")
+            cls._conn = psycopg.connect(DATABASE_URL, autocommit=False, row_factory=dict_row)
+        return cls._conn
+
+    @classmethod
+    def insert_device_with_info(
+        cls,
+        schema_name: str,
+        serial_number: str,
+        udid: str,
+        name: str | None,
+        model: str | None,
+        os_version: str | None,
+    ) -> str | None:
+        """Insert device + device_information in a single transaction.
+
+        Returns device_id (str) if inserted, None if serial/udid conflict.
+        Uses ON CONFLICT DO NOTHING on device_informations to handle duplicates.
+        Transaction ensures no orphan device rows on conflict.
+        """
+        conn = cls._get_conn()
+        with conn.transaction():
+            # Try inserting device_information first to detect conflicts early
+            info_row = conn.execute(
+                f"""
+                INSERT INTO {schema_name}.device_informations
+                    (serial_number, udid, name, model, os_version)
+                VALUES (%(serial)s, %(udid)s, %(name)s, %(model)s, %(os_version)s)
+                ON CONFLICT (serial_number) DO NOTHING
+                RETURNING id
+                """,
+                {
+                    "serial": serial_number,
+                    "udid": udid,
+                    "name": name,
+                    "model": model,
+                    "os_version": os_version,
+                },
+            ).fetchone()
+
+            if info_row is None:
+                # Conflict — serial already exists, skip device insert
+                return None
+
+            # No conflict — insert device and link via device_id
+            device_row = conn.execute(
+                f"""
+                INSERT INTO {schema_name}.devices (state_id, current_policy_id)
+                VALUES (%(state_id)s, %(policy_id)s)
+                RETURNING id
+                """,
+                {"state_id": INITIAL_STATE_ID, "policy_id": INITIAL_POLICY_ID},
+            ).fetchone()
+            device_id = str(device_row["id"])
+
+            # Link device_information to device
+            conn.execute(
+                f"""
+                UPDATE {schema_name}.device_informations
+                SET device_id = %(device_id)s
+                WHERE id = %(info_id)s
+                """,
+                {"device_id": device_id, "info_id": str(info_row["id"])},
+            )
+
+            return device_id

--- a/fluxion-backend/modules/upload_processor/src/exceptions.py
+++ b/fluxion-backend/modules/upload_processor/src/exceptions.py
@@ -1,2 +1,9 @@
+"""Custom exceptions for upload_processor."""
+
+
 class FluxionError(Exception):
-    """Base exception for this module."""
+    """Base exception with error_type for structured error reporting."""
+
+    def __init__(self, message: str, error_type: str = "INTERNAL_ERROR"):
+        super().__init__(message)
+        self.error_type = error_type

--- a/fluxion-backend/modules/upload_processor/src/handler.py
+++ b/fluxion-backend/modules/upload_processor/src/handler.py
@@ -1,9 +1,43 @@
+"""Lambda handler for upload_processor — SQS-triggered device insertion."""
+
+import json
+
 from aws_lambda_powertools.utilities.typing import LambdaContext
 from config import logger, tracer
+from db import DBConnection
+from utils import validate_tenant_id
 
 
 @logger.inject_lambda_context
 @tracer.capture_lambda_handler
 def handler(event: dict, context: LambdaContext) -> dict:
-    """Lambda handler for upload_processor."""
-    raise NotImplementedError
+    """Process SQS messages — insert devices with device_informations."""
+    batch_failures = []
+    logger.debug("Event received", extra={"event": event})
+
+    for record in event.get("Records", []):
+        message_id = record["messageId"]
+        try:
+            body = json.loads(record["body"])
+            tenant = validate_tenant_id(body["tenantId"])
+
+            device_id = DBConnection.insert_device_with_info(
+                schema_name=tenant,
+                serial_number=body["serialNumber"],
+                udid=body["udid"],
+                name=body.get("name"),
+                model=body.get("model"),
+                os_version=body.get("osVersion"),
+            )
+
+            if device_id:
+                logger.info("Device created", extra={"device_id": device_id, "serial": body["serialNumber"]})
+            else:
+                logger.info("Device skipped (duplicate)", extra={"serial": body["serialNumber"]})
+
+        except Exception:
+            logger.exception("Failed to process message", extra={"message_id": message_id})
+            batch_failures.append({"itemIdentifier": message_id})
+
+    # SQS partial batch failure reporting
+    return {"batchItemFailures": batch_failures}

--- a/fluxion-backend/modules/upload_processor/src/tests/test_handler.py
+++ b/fluxion-backend/modules/upload_processor/src/tests/test_handler.py
@@ -1,5 +1,104 @@
-"""Tests for upload_processor handler."""
+"""Tests for upload_processor handler — mock DBConnection, test SQS batch processing."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+# Mock config before importing handler (Lambda Powertools needs env vars)
+with patch.dict(
+    "os.environ",
+    {
+        "POWERTOOLS_SERVICE_NAME": "test",
+        "POWERTOOLS_TRACE_DISABLED": "1",
+    },
+):
+    from db import DBConnection
+    from handler import handler
 
 
-def test_placeholder():
-    assert True
+def _make_sqs_event(records: list[dict]) -> dict:
+    """Build a minimal SQS event with message bodies."""
+    return {
+        "Records": [
+            {
+                "messageId": f"msg-{i}",
+                "body": json.dumps(rec),
+            }
+            for i, rec in enumerate(records)
+        ],
+    }
+
+
+def _device_msg(serial: str, udid: str, tenant: str = "test_tenant") -> dict:
+    return {
+        "serialNumber": serial,
+        "udid": udid,
+        "name": "iPhone 15",
+        "model": "iPhone15,2",
+        "osVersion": "17.0",
+        "tenantId": tenant,
+    }
+
+
+class TestUploadProcessor:
+    @patch.object(DBConnection, "insert_device_with_info")
+    def test_happy_path(self, mock_insert):
+        """Single record → device inserted, no batch failures."""
+        mock_insert.return_value = "device-001"
+        event = _make_sqs_event([_device_msg("SN1", "UD1")])
+        result = handler(event, MagicMock())
+
+        assert result["batchItemFailures"] == []
+        mock_insert.assert_called_once_with(
+            schema_name="test_tenant",
+            serial_number="SN1",
+            udid="UD1",
+            name="iPhone 15",
+            model="iPhone15,2",
+            os_version="17.0",
+        )
+
+    @patch.object(DBConnection, "insert_device_with_info")
+    def test_duplicate_returns_none(self, mock_insert):
+        """Duplicate serial → returns None, no error, no batch failure."""
+        mock_insert.return_value = None
+        event = _make_sqs_event([_device_msg("SN-DUP", "UD-DUP")])
+        result = handler(event, MagicMock())
+
+        assert result["batchItemFailures"] == []
+        mock_insert.assert_called_once()
+
+    @patch.object(DBConnection, "insert_device_with_info")
+    def test_multiple_records(self, mock_insert):
+        """3 records all succeed → empty batchItemFailures."""
+        mock_insert.side_effect = ["dev-1", "dev-2", "dev-3"]
+        event = _make_sqs_event([
+            _device_msg("SN1", "UD1"),
+            _device_msg("SN2", "UD2"),
+            _device_msg("SN3", "UD3"),
+        ])
+        result = handler(event, MagicMock())
+
+        assert result["batchItemFailures"] == []
+        assert mock_insert.call_count == 3
+
+    @patch.object(DBConnection, "insert_device_with_info")
+    def test_partial_failure(self, mock_insert):
+        """2 records, second fails DB → batchItemFailures has 1 entry."""
+        mock_insert.side_effect = ["dev-1", Exception("DB error")]
+        event = _make_sqs_event([
+            _device_msg("SN1", "UD1"),
+            _device_msg("SN2", "UD2"),
+        ])
+        result = handler(event, MagicMock())
+
+        assert len(result["batchItemFailures"]) == 1
+        assert result["batchItemFailures"][0]["itemIdentifier"] == "msg-1"
+
+    @patch.object(DBConnection, "insert_device_with_info")
+    def test_invalid_tenant_id(self, mock_insert):
+        """Invalid tenant → ValueError → batch failure."""
+        event = _make_sqs_event([_device_msg("SN1", "UD1", tenant="bad;tenant")])
+        result = handler(event, MagicMock())
+
+        assert len(result["batchItemFailures"]) == 1
+        mock_insert.assert_not_called()

--- a/fluxion-backend/modules/upload_processor/src/utils.py
+++ b/fluxion-backend/modules/upload_processor/src/utils.py
@@ -1,1 +1,10 @@
 """Utility functions for upload_processor."""
+
+import re
+
+
+def validate_tenant_id(tenant_id: str) -> str:
+    """Validate tenant_id format (alphanumeric + underscore only) to prevent SQL injection."""
+    if not re.match(r"^[a-zA-Z0-9_]+$", tenant_id):
+        raise ValueError("Invalid tenant_id format")
+    return tenant_id


### PR DESCRIPTION
## Summary
- Implement 3 SQS-triggered Lambda workers for async business logic
- Add Terraform compute module (9 Lambdas via `for_each`) + messaging additions

### upload_processor (simplest)
- SQS → INSERT device + device_information with ON CONFLICT DO NOTHING
- Transaction ensures no orphan device rows on duplicate serial

### action_trigger
- SQS → INSERT action_execution + UPDATE device.assigned_action_id (transactional)
- Query device_tokens for push credentials
- Publish MDM command to `fluxion-command-sns` (consumed by OEM processor)

### checkin_handler (most complex)
- 4 event types from OEM processor via SQS:
  - `DEVICE_TOKEN_UPDATE` → UPSERT device_tokens
  - `DEVICE_RELEASED` → update device state + AppSync subscription
  - `ACTION_COMPLETED` → update execution + apply policy + milestone + 2 AppSync subscriptions
  - `ACTION_FAILED` → mark execution failed + clear action + AppSync subscription
- AppSync mutations called via IAM (SigV4) auth
- Generic DB layer: `update_device`, `update_action_execution`, `insert_milestone`, `update_device_token`

### Terraform
- **Messaging additions:** checkin-handler SQS + DLQ, command SNS topic, DynamoDB idempotency table
- **Compute module:** 9 Lambdas (6 resolvers + 3 workers) via `for_each`, ECR repos, IAM roles with least-privilege policies, SQS event source mappings with `ReportBatchItemFailures`
- **Root main.tf:** wired all module outputs (messaging → compute → api)

## Changes
- `modules/upload_processor/src/` — 6 files + tests (5 tests)
- `modules/action_trigger/src/` — 7 files + tests (5 tests)
- `modules/checkin_handler/src/` — 7 files + tests (8 tests)
- `infra/modules/messaging/` — main.tf, outputs.tf additions
- `infra/modules/compute/` — main.tf, variables.tf, outputs.tf (full implementation)
- `infra/main.tf` — compute module wiring

## Test Plan
- [x] `pytest` upload_processor: 5 tests (happy, duplicate, multi-record, partial failure, invalid tenant)
- [x] `pytest` action_trigger: 5 tests (happy, no tokens, multi-record, partial failure, config priority)
- [x] `pytest` checkin_handler: 8 tests (token update, release, action complete + variables + not found, action failed, unknown type, mixed partial)
- [x] `ruff check` clean for all 3 modules
- [x] `terraform validate` passes

Closes #36