### PR TITLE
[chore]: fix frontend prettier on terraform README

### DIFF
--- a/fluxion-frontend/.prettierignore
+++ b/fluxion-frontend/.prettierignore
@@ -1,0 +1,14 @@
+# Build + dep artifacts
+node_modules/
+dist/
+build/
+coverage/
+.vite/
+
+# Lockfile (Prettier cannot parse text-format bun.lock)
+bun.lock
+
+# Terraform local state + provider caches
+terraform/**/.terraform/
+terraform/**/terraform.tfstate
+terraform/**/terraform.tfstate.backup

--- a/fluxion-frontend/terraform/bootstrap/README.md
+++ b/fluxion-frontend/terraform/bootstrap/README.md
@@ -20,16 +20,19 @@ This feature requires **Terraform >= 1.10**.
 ## Step-by-step
 
 1. Change into the bootstrap directory:
+
    ```
    cd terraform/bootstrap
    ```
 
 2. Initialise with local state:
+
    ```
    terraform init
    ```
 
 3. Create the S3 bucket:
+
    ```
    terraform apply -var=resource_name_prefix=fluxion-frontend
    ```
@@ -37,11 +40,13 @@ This feature requires **Terraform >= 1.10**.
 4. Copy the `state_bucket` output value — you will need it in step 6.
 
 5. Change into the dev environment directory:
+
    ```
    cd ../envs/dev
    ```
 
 6. Initialise the remote backend (substitute the bucket name from step 4):
+
    ```
    terraform init -backend-config="bucket=<state_bucket>"
    ```


### PR DESCRIPTION
## Summary

- `bun run format` reflows `fluxion-frontend/terraform/bootstrap/README.md` — Phase 06 subagent wrote it post-frontend-setup, so it bypassed prettier.
- Add `.prettierignore` to exclude `.terraform/` provider cache (giant binary crashes prettier with "Invalid string length") + `bun.lock` + build artifacts.

## Context

Fix the last red CI gate from the #29 scaffold. Backend + OEM already green after `[#29]: fix CI gates` (`3ac1231`).

## Test plan

- [x] `bun run format:check` — pass
- [x] `bun run lint` — pass (0 warnings)
- [x] `bun run typecheck` — pass
- [x] `bun run test` — 1/1 pass
- [ ] CI `CI — fluxion-frontend` — waiting green on this PR

Closes nothing (tiny chore).