### PR TITLE
[#61]: foundation docs for phase 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,39 @@
+# Local planning artifacts (not synced to remote)
+plans/
+
+# macOS
+.DS_Store
+
+# Editor / IDE
+.vscode/
+.idea/
+*.swp
+
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+venv/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+
+# Node / frontend
+node_modules/
+dist/
+build/
+.vite/
+coverage/
+
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.*
+*.tfvars
+!terraform.tfvars.example
+
+# Secrets / env
+.env
+.env.*
+!.env.example

--- a/docs/code-standards.md
+++ b/docs/code-standards.md
@@ -1,0 +1,515 @@
+# Code Standards
+
+> **Version:** v1.0
+> **Audience:** Fluxion contributors (human + LLM) and reviewers.
+> **Authority:** Source of truth. Tooling configs (pre-commit, CI) enforce these rules in follow-up tickets.
+> **Principles:** YAGNI — You Aren't Gonna Need It. KISS — Keep It Simple, Stupid. DRY — Don't Repeat Yourself.
+
+---
+
+## 1. Introduction
+
+Fluxion is an AWS serverless MDM platform targeting the Vietnamese installment / rental phone market. Code must be shippable by a solo developer, reviewable by a thesis committee, and extensible once contributors onboard.
+
+This document declares rules. Enforcement (pre-commit hooks, CI gates) is a follow-up ticket. Until then, rules are **self-enforced** via a PR review checklist that cites the section numbers below.
+
+**When in doubt:** prefer the simpler option. If a rule blocks delivery, open an issue to adjust the doc — do not silently break it.
+
+---
+
+## 2. General Rules
+
+### 2.1 File Naming
+
+| Language | Convention | Example | Note |
+|----------|------------|---------|------|
+| Python (modules) | `snake_case.py` | `device_repository.py` | PEP 8 mandatory; importable modules must be snake_case. |
+| Python (Lambda package dirs) | `snake_case/` | `device_resolver/`, `action_trigger/` | Must match handler import path. AWS Lambda resolves `action_trigger.handler` → imports `action_trigger/handler.py`. Hyphens break imports. |
+| TypeScript (components) | `PascalCase.tsx` | `DeviceTable.tsx` | React / TypeScript official standard. |
+| TypeScript (hooks) | `kebab-case.ts` with `use-` prefix | `use-device-list.ts` | 2026 consensus (TanStack, shadcn/ui). |
+| TypeScript (utilities, services) | `kebab-case.ts` | `format-date.ts`, `api-client.ts` | 2026 consensus. |
+| TypeScript (types, DTOs) | `kebab-case.ts` | `device-types.ts`, `api-responses.ts` | Consistency with utilities; types exported within are PascalCase. |
+| TypeScript (CSS Modules) | `kebab-case.module.css` | `device-table.module.css` | Matches component (kebab variant). Tailwind utility-first preferred; CSS Modules only when scoped styles needed. |
+| TypeScript (config, constants) | `kebab-case.ts` file; `UPPER_SNAKE_CASE` exports | `device-constants.ts` exports `DEVICE_STATES` | Ecosystem standard (Vite, Next.js config files). |
+| TypeScript (tests) | `PascalCase.test.tsx` or `kebab-case.test.ts` | `DeviceTable.test.tsx`, `format-date.test.ts` | Matches the file under test. |
+| Terraform modules | `kebab-case/` | `terraform/modules/compute/` | HashiCorp convention. |
+| Shell scripts | `kebab-case.sh` | `deploy-stack.sh` | POSIX convention. |
+| SQL / Alembic migrations | `NNNN_snake_case.py` | `0042_add_tacs_table.py` | Alembic auto-generates this pattern; keep as-is. |
+
+**Descriptive > short.** `device_enrollment_handler.py` is better than `handler.py`.
+
+**Path aliases (TypeScript):** configure `@/*` → `src/*` in both `tsconfig.json` and `vite.config.ts`. Prefer absolute imports via alias over relative paths beyond two levels (`../../../` is a smell).
+
+**Feature-based organization (recommended):** group by business feature (`features/devices/`, `features/actions/`) rather than purely by technical layer (`components/`, `utils/` at root). Improves colocation and discoverability. See [module-structure.md](module-structure.md) for layout details.
+
+**Evidence sources:** [PEP 8](https://peps.python.org/pep-0008/), [AWS Lambda Python handler docs](https://docs.aws.amazon.com/lambda/latest/dg/python-handler.html), [TanStack Router naming](https://tanstack.com/router/latest/docs/framework/react/routing/file-naming-conventions), [shadcn/ui](https://ui.shadcn.com/docs/installation/manual), [Alembic naming](https://alembic.sqlalchemy.org/en/latest/naming.html). Research notes: [researcher-260419-1545-file-naming-conventions-2026.md](../plans/reports/researcher-260419-1545-file-naming-conventions-2026.md).
+
+### 2.2 File Size
+
+- **Hard limit:** 200 LOC per source file (excluding blank lines, docstrings, imports).
+- **Lambda `handler.py` entry:** ≤ 50 LOC — wire only, delegate to business logic modules.
+- **React component:** ≤ 150 LOC.
+- **Terraform `main.tf`:** ≤ 300 LOC (split via sub-modules if over).
+
+When over limit, split by concern (queries vs mutations, presentational vs container) — see [module-structure.md](module-structure.md).
+
+### 2.3 Comments
+
+- **Why, not what.** Code already says what; comment explains why.
+- **No AI references** in comments or commit messages.
+- **No `TODO` without issue link.** `# TODO(#123): handle APNS rate limit` ✅. `# TODO: fix later` ❌.
+- **No commented-out code.** Delete it. Git history preserves it.
+- **Docstrings for public functions** (see §3.2).
+
+**Do:**
+
+```python
+# APNS returns 410 for tokens revoked by iOS. Treat as permanent, not transient.
+if response.status == 410:
+    repository.mark_push_token_invalid(device_id)
+```
+
+**Don't:**
+
+```python
+# Check if status is 410
+if response.status == 410:  # mark invalid
+    repository.mark_push_token_invalid(device_id)
+```
+
+### 2.4 Error Handling
+
+- **Validate at boundaries only** (handler entry, external API responses). Trust internal code.
+- **No bare `except`** (Python) or empty `catch` (TS). Always catch specific types.
+- **Re-raise with context**, don't swallow.
+- **Structured errors:** domain errors extend a base class (`FluxionError`), map to HTTP / GraphQL errors at boundary.
+
+**Do:**
+
+```python
+try:
+    device = repository.get_device(device_id)
+except psycopg2.OperationalError as e:
+    logger.exception("db.connection_lost", extra={"device_id": device_id})
+    raise TransientError("Database unavailable") from e
+```
+
+**Don't:**
+
+```python
+try:
+    device = repository.get_device(device_id)
+except Exception:
+    return None  # hides bugs, caller can't tell failure from missing
+```
+
+### 2.5 Logging
+
+- **Structured JSON only.** Use `python-json-logger` / `pino`.
+- **Event naming:** `<entity>.<action>.<outcome>` — `device.enrolled`, `action.dispatched`, `apns.push_failed`.
+- **No PII in logs.** Device serial OK; customer name / phone number NOT OK.
+- **Correlation ID propagation:** pass `correlation_id` through SNS/SQS message attributes, include in every log line.
+
+**Do:**
+
+```python
+logger.info(
+    "device.enrolled",
+    extra={"device_id": d.id, "tenant_id": t.id, "correlation_id": ctx.correlation_id},
+)
+```
+
+**Don't:**
+
+```python
+print(f"device {d.id} enrolled for customer {customer.full_name}")  # PII leak + unstructured
+```
+
+### 2.6 Security
+
+- **No secrets in code or git history.** Use AWS Secrets Manager / Parameter Store. `.env` files in `.gitignore`.
+- **Parameterized SQL only.** See §5.1.
+- **Input validation at handler boundary** via Pydantic / Zod. Reject unknown fields strictly.
+- **Least privilege IAM.** Lambda role grants only actions needed — no `*` wildcard on production.
+- **No `eval` / `exec`** on user input. Ever.
+- **OWASP Top 10 awareness** — each PR touching auth / input / output must cite threat model notes in description.
+
+---
+
+## 3. Python Rules
+
+**Target runtime:** Python 3.12 on AWS Lambda (container image).
+**Formatter/Linter:** [Ruff](https://docs.astral.sh/ruff/) — single tool replacing Black + isort + flake8 + pylint (≈20× faster, 2026 ecosystem standard). Commands: `ruff format` + `ruff check --select ALL` (justified `# noqa: <RULE>` with reason).
+**Type checker:** `mypy --strict`.
+
+### 3.1 Type Hints
+
+- **100% coverage** — every parameter, return value, class attribute.
+- Use `from __future__ import annotations` at top of every file (defers evaluation, allows forward refs).
+- Prefer built-in generics (`list[str]`, `dict[str, int]`) over `typing.List` / `typing.Dict`.
+- Use `Literal`, `TypedDict`, `NotRequired` where applicable.
+- For SQLAlchemy, prefer 2.0 style types (`Engine`, `Connection` from `sqlalchemy.engine`; `Result` for return values) — not legacy `engine.Engine` module-path syntax.
+
+**Do:**
+
+```python
+from __future__ import annotations
+
+def enroll_device(tenant_id: str, serial: str) -> Device:
+    ...
+```
+
+**Don't:**
+
+```python
+def enroll_device(tenant_id, serial):  # no hints
+    ...
+```
+
+### 3.2 Docstrings
+
+- **Mandatory on public functions / classes** (no leading underscore).
+- **Google style.** Include `Args`, `Returns`, `Raises` sections.
+- **First line:** imperative mood, ends with period, ≤ 80 chars.
+
+**Do:**
+
+```python
+def enroll_device(tenant_id: str, serial: str) -> Device:
+    """Register a new device in the `registered` state for a tenant.
+
+    Args:
+        tenant_id: UUID of the owning tenant.
+        serial: Device serial number (IMEI for Apple).
+
+    Returns:
+        Device DTO with generated id and initial state.
+
+    Raises:
+        ConflictError: Serial already registered for this tenant.
+    """
+```
+
+### 3.3 Error Handling Specifics
+
+- Define domain errors in `errors.py` per module, extending `FluxionError`.
+- At handler boundary, map to AppSync error response with stable error codes.
+- Never raise `Exception` directly; always a specific subclass.
+
+### 3.4 Pydantic at Boundaries
+
+- **Every handler entry** parses `event["arguments"]` into a Pydantic model.
+- **Every repository return** is a Pydantic DTO, not a raw cursor row.
+- **Every external API response** parsed through Pydantic before use.
+- Use `model_config = ConfigDict(extra="forbid")` — reject unknown fields.
+
+**Do:**
+
+```python
+class EnrollDeviceInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    serial: str
+    platform: Platform
+
+def handler(event, context):
+    args = EnrollDeviceInput.model_validate(event["arguments"])
+    ...
+```
+
+### 3.5 Imports
+
+- **Absolute imports only, no `src.` prefix** — `from config import logger`, not `from src.config import logger` and not relative `from .config import ...`.
+  - Rationale: Lambda runtime copies `src/` contents flat into `LAMBDA_TASK_ROOT`. Tests mirror this via `pyproject.toml` → `[tool.pytest.ini_options] pythonpath = ["src"]`. Handlers import the same way in both contexts.
+- **Grouped** (PEP 8): stdlib → third-party → local, blank line between groups.
+- **No wildcard imports** (`from x import *`).
+- **No circular deps** — enforce via `import-linter` when tooling ticket lands.
+
+### 3.6 Async
+
+- Prefer `aioboto3` for I/O-bound Lambda (SNS publish, S3 get).
+- Don't mix sync/async in one handler — pick one.
+- Use `asyncio.gather` with `return_exceptions=True` for fan-out, inspect results.
+
+### 3.7 Strict Target
+
+| Tool | Command | Must Pass |
+|------|---------|-----------|
+| Formatter | `ruff format --check .` | Yes |
+| Linter | `ruff check --select ALL .` | Yes (w/ justified `noqa`) |
+| Type checker | `mypy --strict src/` | Yes |
+| Security | `bandit -r src/` | No high-severity findings |
+
+---
+
+## 4. TypeScript Rules
+
+**Target runtime:** Node 20+ (frontend build), React 19, Vite.
+**Formatter:** Prettier (default config, 100-char line).
+**Linter:** `eslint:recommended` + `@typescript-eslint/strict` + `eslint-plugin-react-hooks`.
+**Type checker:** `tsc --strict` (strictest — see §4.1).
+
+### 4.1 Strict Mode
+
+`tsconfig.json` must include:
+
+```json
+{
+  "compilerOptions": {
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "exactOptionalPropertyTypes": true
+  }
+}
+```
+
+### 4.2 No `any`, No `!`
+
+- **No `any`** — use `unknown` and narrow.
+- **No `!` non-null assertion** outside tests. Use type guards or explicit null checks.
+- **No `@ts-ignore`**, `@ts-expect-error` only with inline comment explaining why.
+
+**Do:**
+
+```ts
+const device = devices.find(d => d.id === id);
+if (!device) throw new NotFoundError(`device ${id}`);
+// TS knows device is Device here
+```
+
+**Don't:**
+
+```ts
+const device = devices.find(d => d.id === id)!;  // lies to compiler
+```
+
+### 4.3 Explicit Return Types
+
+- **Exported functions / hooks** must have explicit return types.
+- Internal one-liners can infer.
+
+**Do:**
+
+```ts
+export function useDeviceList(tenantId: string): DeviceListResult {
+    ...
+}
+```
+
+### 4.4 Interface over Type
+
+- Prefer `interface` for object shapes (extendability, better error messages).
+- Use `type` for unions, tuples, mapped types.
+
+### 4.5 Imports and Path Alias
+
+- Configure `@/*` alias → `src/*` in `tsconfig.json` + Vite.
+- Prefer absolute imports via alias over deep relative (`../../../`).
+- Group: external → aliased → relative, blank line between.
+
+### 4.6 Strict Target
+
+| Tool | Command | Must Pass |
+|------|---------|-----------|
+| Formatter | `prettier --check .` | Yes |
+| Linter | `eslint . --max-warnings 0` | Yes |
+| Type checker | `tsc --noEmit` | Yes |
+
+---
+
+## 5. SQL Rules
+
+**Target DB:** PostgreSQL 15+.
+**Migration tool:** Alembic (via psycopg2-binary).
+
+### 5.1 Parameterized Queries Only
+
+- **Never** string-concat / f-string user input into SQL.
+- Fluxion uses **SQLAlchemy 2.0** with `text()` + named params (`:name` style) everywhere.
+- Tenant schema names are the single exception to the f-string rule: they can be interpolated into the SQL **only after** the regex validation in `Connection.get_schema_name` (see [design-patterns.md §11.2](design-patterns.md)).
+
+**Do (SQLAlchemy, named params):**
+
+```python
+from sqlalchemy import text
+
+query = text(f"SELECT * FROM {schema}.devices WHERE serial = :serial")
+row = conn._execute(query, {"serial": serial}).fetchone()
+```
+
+**Don't:**
+
+```python
+conn._execute(text(f"SELECT * FROM {schema}.devices WHERE serial = '{serial}'"))  # SQL injection
+conn._execute(text("SELECT * FROM devices WHERE serial = %s"), (serial,))        # wrong param style
+```
+
+### 5.2 Migration Style
+
+- **Up and down both required.** Every migration is reversible.
+- **Idempotent** — `CREATE TABLE IF NOT EXISTS`, `ADD COLUMN IF NOT EXISTS` where supported.
+- **One logical change per migration.** No mixing schema + data seed in same file.
+- **Data migrations separate** from DDL migrations, numbered sequentially.
+
+### 5.3 Naming
+
+| Object | Convention | Example |
+|--------|------------|---------|
+| Tables | plural snake_case | `devices`, `batch_device_actions` |
+| Columns | snake_case | `created_at`, `push_token` |
+| Foreign keys | `<entity>_id` | `tenant_id`, `device_id` |
+| Timestamps | `<verb>_at` | `enrolled_at`, `locked_at` |
+| Booleans | `is_<adjective>` / `has_<noun>` | `is_locked`, `has_active_chat` |
+| Indexes | `ix_<table>_<cols>` | `ix_devices_tenant_id_serial` |
+| Unique constraints | `uq_<table>_<cols>` | `uq_devices_tenant_id_serial` |
+
+### 5.4 Indexes
+
+- **Declare explicitly** in migrations — never rely on ORM auto-generation.
+- **Composite index order matters:** most selective column first.
+- **Never index high-churn bool columns** without partial index.
+
+---
+
+## 6. Git Rules
+
+### 6.1 Commit Message Format
+
+Format: `[<ticket>]: <subject>`
+
+- **Ticket** is the GitHub issue number with `#`, e.g. `[#34]`. If there is truly no ticket (hotfix on a dead system, emergency rollback), use `[chore]` — but the default is a ticket.
+- **Subject** is imperative mood, lowercase first word, ≤ 72 chars, no trailing period. Describe the change, not the process.
+- **No scope, no type prefix, no conventional-commits syntax.** Ticket number already groups changes; the diff shows the type.
+- **Body** (optional, blank line after subject) explains *why* when non-obvious. Hard-wrap at 72.
+- **Footer** (optional) for `Closes #N`, `Related #M`.
+
+**Do:**
+
+```
+[#34]: add device enrollment handler
+
+Handler parses AppSync event, delegates to DeviceRepository.enroll,
+maps SerialAlreadyRegistered to GraphQL error code CONFLICT.
+
+Closes #34
+```
+
+```
+[#50]: retry on APNS 503 with exponential backoff
+```
+
+```
+[#61]: foundation docs for phase 3
+```
+
+**Don't:**
+
+```
+feat(#34): add device handler          # old conventional-commits syntax
+[34]: add device handler                # missing # in ticket
+Added device handler.                   # not imperative, ends with period
+[#34] add device handler                # missing colon after ]
+WIP                                     # not descriptive
+```
+
+### 6.2 No AI References
+
+Commit messages, PR descriptions, code comments must not reference AI assistants (Claude, Copilot, ChatGPT). Describe the change, not the author.
+
+### 6.3 Branch-per-Ticket Workflow (Mandatory)
+
+Every ticket gets its own branch. No direct commits to `main` except exceptional hotfixes (documented post-hoc).
+
+**Flow:**
+
+1. Create branch from `main`: `git checkout main && git pull && git checkout -b feature/29-monorepo-scaffold`
+2. Commit **one commit per phase** while implementing — each phase in the plan becomes one commit. Keeps history reviewable and bisect-friendly.
+3. Push branch early (even before full completion): `git push -u origin feature/29-monorepo-scaffold`
+4. Open PR when all phases done (or as draft earlier to share progress).
+5. Merge via GitHub (squash or merge commit — project-level choice, currently squash to keep main history linear).
+6. Delete branch after merge.
+
+### 6.4 Branch Naming
+
+Format: `<type>/<ticket-number>-<short-kebab-slug>`
+
+Types:
+
+| Type | When |
+|------|------|
+| `feature/` | New capability, matches a `[T*]` ticket |
+| `bugfix/` | Fix a reported bug |
+| `hotfix/` | Urgent production fix branching off `main` |
+| `chore/` | Tooling / config / docs with no ticket number — use `chore/short-slug` (no ticket segment) |
+| `refactor/` | Internal restructuring, no behaviour change |
+
+**Examples:**
+
+```
+feature/29-monorepo-scaffold
+feature/34-device-resolver
+bugfix/50-apns-retry-backoff
+hotfix/schema-graphql-syntax-error
+refactor/60-extract-fsm-tables
+chore/bump-ruff-version
+```
+
+Slug ≤ 30 chars, kebab-case, omit filler words.
+
+### 6.5 Pull Request Conventions
+
+- **Title** = `[#<ticket>]: <subject>` (same format as commits; copy first commit's subject).
+- **Body** must contain:
+  - Summary of change (2-5 bullets).
+  - Link to plan: `Plan: plans/YYMMDD-HHMM-<slug>/plan.md`.
+  - Docs citations (`Follows docs/code-standards.md §3.4`).
+  - Test plan as checkbox list.
+  - Closing footer: `Closes #<ticket>`.
+- **Draft PRs** are encouraged for work-in-progress — flip to ready when all phases landed + CI green.
+- **Commit-per-phase retained** after squash by including phase list in PR body.
+- **No `--no-verify` / hook skip** unless explicit reviewer approval in PR comment.
+- **No force-push to main** ever. Force-push to own feature branch is OK before merge; always use `--force-with-lease`.
+
+---
+
+## 7. Tooling Targets (Declared, Enforcement Pending)
+
+These commands **will be** CI gates. Until the pre-commit / CI ticket lands, run locally before every commit.
+
+| Stack | Tool | Command | CI Gate |
+|-------|------|---------|---------|
+| Python | ruff (format) | `ruff format --check .` | Fail on diff |
+| Python | ruff (lint) | `ruff check --select ALL .` | Fail on error |
+| Python | mypy | `mypy --strict src/` | Fail on error |
+| Python | bandit | `bandit -r src/ -ll` | Fail on high severity |
+| Python | pytest | `pytest --cov --cov-fail-under=80` | Fail under 80% |
+| TypeScript | prettier | `prettier --check .` | Fail on diff |
+| TypeScript | eslint | `eslint . --max-warnings 0` | Fail on warning |
+| TypeScript | tsc | `tsc --noEmit` | Fail on error |
+| TypeScript | vitest | `vitest run --coverage` | Fail under 80% |
+| Terraform | fmt | `terraform fmt -check -recursive` | Fail on diff |
+| Terraform | validate | `terraform validate` | Fail on error |
+| Terraform | tflint | `tflint --recursive` | Fail on error |
+| SQL | sqlfluff | `sqlfluff lint migrations/` | Fail on error |
+| Commits | commitlint | `commitlint --from origin/main` | Fail on non-conforming |
+
+---
+
+## 8. References
+
+- **Wiki T2** — Theoretical foundations (architecture principles).
+- **Wiki T3** — FSM and Harel Statechart theory (patterns referenced in §3).
+- **Wiki T4** — System architecture design (module boundaries).
+- **Wiki T5** — API Contract + ER Diagram (schema conventions in §5).
+- [module-structure.md](module-structure.md) — stack-specific layouts
+- [design-patterns.md](design-patterns.md) — patterns the rules presuppose
+- [testing-guide.md](testing-guide.md) — test naming and coverage rules
+
+---
+
+## 9. Change Log
+
+| Version | Date | Change |
+|---------|------|--------|
+| v1.0 | 2026-04-19 | Initial release (#61). |

--- a/docs/design-patterns.md
+++ b/docs/design-patterns.md
@@ -1,0 +1,525 @@
+# Design Patterns
+
+> **Version:** v1.0
+> **Audience:** Fluxion contributors building Lambda resolvers, workers, and the React console.
+> **Authority:** Patterns the codebase presupposes. Pairs with [code-standards.md](code-standards.md) (rules) and [module-structure.md](module-structure.md) (layout).
+> **Principle:** Patterns exist to solve recurring problems. If the problem has not appeared twice, do not adopt the pattern (YAGNI).
+
+---
+
+## 1. Introduction
+
+Fluxion uses a small, deliberate set of patterns. This document lists each one, the problem it solves, the Fluxion-specific implementation, and the common mistakes to avoid.
+
+**Ground rules:**
+
+- **No shared code modules.** Each Lambda is self-contained (see [module-structure.md §2.2](module-structure.md)). When a pattern requires boilerplate, it is copied per Lambda — not imported. If the boilerplate becomes painful, the answer is an AWS Lambda Layer, not a new top-level `shared/` dir.
+- **Patterns are not architecture.** Do not introduce a pattern because "it's good practice." Introduce it when a concrete Fluxion need appears (a second Lambda needs the same shape, an external call starts timing out, etc.).
+- **Prefer dumb code over clever pattern.** A 10-line function is better than a 3-file abstraction that "encapsulates future change."
+
+---
+
+## 2. Choreography Saga
+
+**Problem.** An assignment of an action to a device must cross multiple Lambdas and external systems:
+1. Operator calls `assignAction` via AppSync.
+2. `action_resolver` records intent in `action_logs`.
+3. `action_trigger` Lambda consumes an SNS event, fans out per-device SQS messages.
+4. `apple_process_action` (OEM worker) sends APNS push.
+5. Device checks in; `checkin_handler` Lambda updates FSM state.
+
+Wrapping all five steps in a single synchronous handler would couple them, extend Lambda timeout risk, and lose the at-least-once durability of SQS.
+
+**Solution — Choreography Saga.** Each Lambda owns one step, publishes an event when done, and does not know who consumes it. No central orchestrator. SNS fan-out with SQS per consumer gives retry, DLQ, and observability for free.
+
+**Event naming.** `<entity>.<action>.<outcome>`:
+- `action.assigned` — resolver wrote the intent.
+- `device.push.sent` — OEM worker succeeded.
+- `device.checkin.received` — device responded.
+- `action.completed` / `action.failed` — terminal events for the saga.
+
+**Payload shape.** Every event payload carries a `correlation_id` (UUID from the originating AppSync call) and a `version` field (starts at `"1"`). Consumers must tolerate unknown fields, and reject payloads whose `version` major bump they have not been updated for.
+
+**Fluxion example (pseudocode, per-Lambda duplication allowed):**
+
+```python
+# modules/action_resolver/handler.py
+def lambda_handler(event, context):
+    input_ = AssignActionInput.model_validate(event["arguments"])
+    log = repo.create_action_log(input_, correlation_id=context.aws_request_id)
+    sns.publish(
+        TopicArn=os.environ["ACTION_ASSIGNED_TOPIC"],
+        Message=ActionAssigned(
+            version="1",
+            correlation_id=context.aws_request_id,
+            action_log_id=log.id,
+            device_ids=input_.device_ids,
+        ).model_dump_json(),
+    )
+    return ActionLogOutput.from_model(log).model_dump()
+```
+
+**When NOT to use.** Single-service transactional operations (device update + audit write, both in PostgreSQL) → one DB transaction, not a saga. Distributed transactions across AWS accounts → that is a different problem entirely (use Step Functions Express).
+
+**Common mistakes:**
+- Consumer Lambdas importing the producer's event class. Re-declare Pydantic models per consumer (see [module-structure.md §6](module-structure.md)).
+- Assuming exactly-once delivery. SQS is at-least-once — every consumer must be idempotent (§9).
+- Missing DLQ. Every SQS queue needs one; every DLQ needs a CloudWatch alarm.
+
+---
+
+## 3. Finite State Machine (DB-Driven)
+
+**Problem.** A device moves through a lifecycle — `idle` → `registered` → `enrolled` → `active` ⇄ `locked` → `released`. Transitions are triggered by operator actions, OEM callbacks, or scheduled jobs. Encoding "when can X happen" as `if/else` ladders scattered across resolvers leads to inconsistent behavior and security gaps (e.g., a locked device accepting a lock command).
+
+**Solution — DB-driven FSM.** Four tables define the machine, inside each tenant's schema (see §11 on multi-schema isolation):
+
+| Table | Role |
+|-------|------|
+| `{tenant_schema}.device_states` | Enumerates valid states (`idle`, `enrolled`, `active`, `locked`, `released`). |
+| `{tenant_schema}.state_policies` | Allowed transitions: `from_state`, `to_state`, `action`, guard predicate. |
+| `{tenant_schema}.state_actions` | Actions operators or workers can invoke (`enroll`, `lock`, `release`). |
+| `{tenant_schema}.state_milestones` | Side effects to emit when reaching a target state (SNS events, audit rows). |
+
+**Invariant:** a transition happens **only** via `apply_action(tenant_schema, device_id, action)` which:
+1. Loads the current state (row lock if transition mutates).
+2. Looks up `state_policies` for `(current_state, action)` — `NOT FOUND` → `IllegalTransition`.
+3. Evaluates the guard (e.g., "device must have no unpaid installments to enter `released`").
+4. Updates `devices.state` in the same transaction.
+5. Writes a row to `device_state_transitions` (history).
+6. Emits milestone events post-commit via outbox pattern.
+
+**Fluxion example (schema-qualified, guard in SQL):**
+
+```python
+# modules/action_trigger/handler.py — simplified
+def apply_action(conn, tenant_schema: str, device_id: str, action: str) -> Device:
+    # tenant_schema is validated by caller (Cognito claim) — never user-supplied here
+    with conn.cursor() as cur:
+        cur.execute(
+            f"""
+            WITH cur AS (
+                SELECT state FROM {tenant_schema}.devices WHERE id = %s FOR UPDATE
+            ),
+            policy AS (
+                SELECT p.to_state
+                FROM {tenant_schema}.state_policies p, cur
+                WHERE p.from_state = cur.state AND p.action = %s
+                  AND (p.guard_sql IS NULL OR evaluate_guard(p.guard_sql, %s))
+            )
+            UPDATE {tenant_schema}.devices
+            SET state = (SELECT to_state FROM policy)
+            WHERE id = %s AND (SELECT to_state FROM policy) IS NOT NULL
+            RETURNING *;
+            """,
+            (device_id, action, device_id, device_id),
+        )
+        row = cur.fetchone()
+        if not row:
+            raise IllegalTransition(device_id, action)
+        return Device.model_validate(dict(row))
+```
+
+**Schema name safety.** `tenant_schema` is injected into SQL via f-string, which is normally a SQL-injection red flag. It is safe **only because** the value comes from a validated source (Cognito claim → `meta.tenants.schema_name` lookup at auth time) and is matched against a regex (`^tenant_[a-z0-9_]+$`) before any query. Never accept `tenant_schema` from request arguments directly.
+
+**Why DB-driven.** Policies change without redeploy — operators (with the right role) add a new `action=release` policy row for a new state. Guards stay in SQL so they run in the same transaction as the mutation.
+
+**When NOT to use.** Single-flag toggles (`is_active`) or workflows where transitions are trivial and non-branching — just write `UPDATE devices SET is_active = TRUE`.
+
+**Common mistakes:**
+- Caching FSM state in Lambda memory between invocations. Containers are reused but not guaranteed — always reload from DB.
+- Putting guards in Python and policy rows in SQL. Keep guard logic in one place (SQL here).
+- Emitting milestone events before the transaction commits. Use the outbox pattern: write an event row in the same TX, publish post-commit.
+
+**Reference:** Wiki T5 — DeviceFSM design.
+
+---
+
+## 4. Resolver Pattern (AppSync Lambda)
+
+**Problem.** AppSync routes a GraphQL field to a Lambda. The Lambda must: parse the event, authorize the caller, validate input, call business logic, map errors, serialize output. Mixing these concerns in one function yields 300-LOC handlers that are untestable.
+
+**Solution — thin handler + delegation.** The `handler.py` is a wire: it does the 4 boundary concerns (parse, auth, validate, serialize) and delegates work to sibling modules.
+
+```python
+# modules/device_resolver/handler.py (~40 LOC, under §2.2 budget)
+from __future__ import annotations
+import os, logging
+from shared_logging import configure  # copied per-Lambda, not imported from a shared/ dir
+
+configure()
+logger = logging.getLogger(__name__)
+
+FIELD_HANDLERS = {
+    "getDevice": handle_get_device,
+    "listDevices": handle_list_devices,
+    "enrollDevice": handle_enroll_device,
+}
+
+def lambda_handler(event, context):
+    field = event["info"]["fieldName"]
+    tenant_ctx = tenant_context_from(event)  # parses Cognito claims
+    correlation_id = context.aws_request_id
+
+    logger.info("resolver.invoked", extra={"field": field, "tenant": tenant_ctx.id, "correlation_id": correlation_id})
+    try:
+        return FIELD_HANDLERS[field](event["arguments"], tenant_ctx, correlation_id)
+    except FluxionError as e:
+        return e.to_appsync_error()
+```
+
+**Field-level authorization via decorators.** Decorators live in the Lambda (copied, not imported):
+
+```python
+@require_role("admin")
+@tenant_scoped
+def handle_enroll_device(args, ctx, correlation_id):
+    input_ = EnrollDeviceInput.model_validate(args)
+    device = db.enroll(ctx.tenant_id, input_.serial, input_.platform)
+    return Device.from_row(device).model_dump()
+```
+
+**Config in `config.py` (mandatory).** Every Lambda reads its environment variables exactly once, at module import, in `config.py`. Failures are loud at cold start, not buried inside request handlers.
+
+```python
+# modules/action_trigger/config.py
+import os
+
+ACTION_TRIGGER_SQS = os.environ["ACTION_TRIGGER_SQS"]          # required — fail fast
+ACTION_ASSIGNED_TOPIC = os.environ["ACTION_ASSIGNED_TOPIC"]    # required
+DB_SECRET_ARN = os.environ["DB_SECRET_ARN"]                    # required
+PUSH_TIMEOUT_SECONDS = int(os.environ.get("PUSH_TIMEOUT_SECONDS", "10"))  # optional default
+LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO")
+```
+
+Handlers and services import from `config.py`. They never call `os.environ` directly.
+
+**When NOT to use the pattern.** One-off Lambdas that run a single CLI-style task (a migration helper, a one-shot report generator). A `main()` function is fine.
+
+**Common mistakes:**
+- Putting GraphQL error mapping outside the handler (in business logic). Business logic raises `FluxionError`; only the handler knows about AppSync response shape.
+- Reading environment variables inside request handlers. All env var reads live in `config.py`, evaluated at import. A missing var throws on cold start, not mid-request.
+- Forgetting to log the correlation ID. Every log line in the handler scope must include it.
+
+---
+
+## 5. Repository Pattern
+
+**Problem.** Business logic sprinkled with SQL is un-reviewable: you cannot tell at a glance whether a query respects tenant isolation, uses an index, or handles the "row already locked" race. Embedded `execute(...)` calls also couple business code to `psycopg2` specifics.
+
+**Solution — `db.py` per Lambda.** All data access lives in a single module per Lambda with a clear API. Business logic gets Pydantic DTOs, never raw `dict` rows.
+
+```python
+# modules/device_resolver/db.py
+class DeviceRepository:
+    def __init__(self, conn: psycopg2.extensions.connection, tenant_schema: str) -> None:
+        # tenant_schema comes from validated Cognito context (see §3 schema-name safety note)
+        self._conn = conn
+        self._schema = tenant_schema
+
+    def get_by_id(self, device_id: str) -> Device | None:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"SELECT * FROM {self._schema}.devices WHERE id = %s",
+                (device_id,),
+            )
+            row = cur.fetchone()
+        return Device.model_validate(dict(row)) if row else None
+
+    def enroll(self, serial: str, platform: Platform) -> Device:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"""
+                INSERT INTO {self._schema}.devices (serial, platform, state)
+                VALUES (%s, %s, 'registered')
+                ON CONFLICT (serial) DO NOTHING
+                RETURNING *;
+                """,
+                (serial, platform.value),
+            )
+            row = cur.fetchone()
+        if not row:
+            raise SerialAlreadyRegistered(serial)
+        return Device.model_validate(dict(row))
+```
+
+**Tenant isolation is structural.** With tenant-per-schema, isolation lives in the schema boundary — the `DeviceRepository` is bound to one tenant schema for its entire lifetime. No query has a free `WHERE tenant_id = %s` clause; cross-tenant leaks require a bug in *construction* (wrong schema passed in), not in individual queries.
+
+**Testability.** In unit tests, mock `psycopg2.connection.cursor` (the driver seam), never the `DeviceRepository` class. The class is the thing under test.
+
+**When NOT to use.** A Lambda that executes one query, no branching, no reuse (a health-check endpoint). Inline the `execute` call in the handler.
+
+**Common mistakes:**
+- Repository method returns raw row dicts. Always return Pydantic DTOs — the repository is the shape-validation boundary.
+- Repository calls another repository. Keep it a leaf; if you need composition, do it in business logic, not inside the repository.
+- Testing by mocking the repository class in business-logic tests. That hides SQL correctness bugs. Use a real (in-container) PostgreSQL for business-logic tests (see [testing-guide.md](testing-guide.md)).
+
+---
+
+## 6. Factory Pattern (OEM Abstraction)
+
+**Problem.** Today Fluxion supports Apple devices (APNS + MDM). Tomorrow it needs Samsung Knox, maybe Xiaomi. The `action_trigger` Lambda should not care which OEM a device belongs to — it just asks "push this action to this device."
+
+**Solution — provider interface + registry.** A small abstract base class defines the contract; the registry maps `Platform` enum → provider implementation. OEM-specific code lives in `fluxion-oem/modules/<oem>_process_action/`.
+
+```python
+# fluxion-oem/modules/apple_process_action/provider.py
+class OEMProvider(ABC):
+    @abstractmethod
+    def push_action(self, device: Device, action: Action) -> PushResult: ...
+
+class AppleProvider(OEMProvider):
+    def push_action(self, device, action):
+        # APNS HTTP/2 call, retry + CB, return structured result
+        ...
+
+# Registry lookup:
+PROVIDERS: dict[Platform, type[OEMProvider]] = {Platform.APPLE: AppleProvider}
+```
+
+**No shared `providers/` module.** The `OEMProvider` base class is copied to each OEM worker Lambda because we do not share code across Lambdas (see §1). Duplication here is small (5 lines of ABC) and prevents deploy coupling: updating APNS logic does not force a redeploy of a hypothetical Samsung worker.
+
+**When NOT to use.** Single-OEM codebase with no concrete second OEM on the roadmap. Just write `apple_push(device, action)` directly — a one-OEM "factory" is pure overhead.
+
+**Common mistakes:**
+- Stuffing provider-specific config (APNS bundle IDs, Samsung Knox tenant keys) into a shared config class. Each provider owns its own env vars — the registry reads none.
+- Returning provider-specific exceptions across the boundary. `AppleProvider.push_action` catches `APNSRateLimited` and raises a shared `PushTransientError`.
+
+---
+
+## 7. DTO / Pydantic Boundary Validation
+
+**Problem.** Raw `dict` payloads survive deep into a codebase, causing `KeyError` at 2am and silently accepting malformed input. Type checkers (`mypy`) cannot help with `dict[str, Any]`.
+
+**Solution — Pydantic at every boundary.**
+1. **Input.** Every handler entry parses `event["arguments"]` into a Pydantic model with `extra="forbid"`.
+2. **Repository return.** Queries return Pydantic DTOs, not cursor rows.
+3. **External response.** APNS / OEM responses parsed into Pydantic before the code trusts them.
+4. **Output.** Before returning from a handler, serialize via Pydantic (`.model_dump()`) — never hand-craft the response dict.
+
+```python
+# modules/device_resolver/dto.py
+class EnrollDeviceInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    serial: str = Field(min_length=10, max_length=20, pattern=r"^[A-Z0-9]+$")
+    platform: Platform
+
+class DeviceOutput(BaseModel):
+    id: UUID
+    serial: str
+    state: DeviceState
+    enrolled_at: datetime | None
+```
+
+**Why strict (`extra="forbid"`).** Unknown fields from a misconfigured client are a signal of version drift, not a feature to silently accept.
+
+**When NOT to use.** Never "not use." Every boundary gets Pydantic. The only exception is pass-through proxies (a Lambda that does nothing but re-publish an SNS message verbatim) — and even those are rare.
+
+**Common mistakes:**
+- Skipping validation at the repository boundary. "The DB would not return a bad row" — yes it would, after a failed migration.
+- Using `dict` inside business logic after parsing at the boundary. If Pydantic parsed it, keep it as a model through the whole call stack.
+
+---
+
+## 8. Circuit Breaker
+
+**Problem.** APNS has a bad minute, every `action_trigger` invocation blocks on a 15-second HTTP timeout, the whole Lambda concurrency limit saturates, and AppSync resolvers downstream time out too. One flaky dependency takes out the whole command pipeline.
+
+**Solution — per-container circuit breaker.** Each Lambda container instance tracks its own recent failure rate for each external endpoint. When failures exceed a threshold in a window, the breaker opens and subsequent calls fail fast with a `ServiceUnavailable`. The caller (SQS consumer) can then NACK the message back to the queue with a short visibility timeout — retries are cheap, blocked handlers are not.
+
+```python
+# modules/apple_process_action/push_service.py (sketch)
+breaker = CircuitBreaker(failure_threshold=5, window_seconds=60, half_open_after=30)
+
+def push(device, action):
+    if breaker.is_open():
+        raise PushTransientError("apns breaker open")
+    try:
+        response = apns.send(device.push_token, payload(action))
+        breaker.on_success()
+        return response
+    except (RequestTimeout, ConnectionError) as e:
+        breaker.on_failure()
+        raise PushTransientError("apns transient") from e
+```
+
+**Lambda-specific caveat.** The breaker state lives in the container and is lost on cold start. This is OK — cold starts are rare compared to the burst window we care about. Do **not** back the breaker with a shared store (Redis, DynamoDB) to "improve" this; shared-state breakers add new failure modes (breaker store itself goes down) to prevent a problem the container-local breaker already handles well enough.
+
+**When NOT to use.** Low-QPS endpoints (one call per hour) — the breaker never gathers enough samples to open meaningfully. Rely on timeouts and DLQ instead.
+
+**Common mistakes:**
+- Using the breaker on AWS SDK calls. AWS SDK already has retry with exponential backoff; adding a breaker layers two retry strategies and hides real failures.
+- Opening the breaker on 4xx responses. 4xx means "my request is wrong," retrying does not help — but it is also not a sign the service is down. Track only 5xx + timeouts.
+
+---
+
+## 9. Idempotency
+
+**Problem.** SQS delivers at-least-once. AppSync retries on transient failures. An event that enrolls a device can arrive twice, creating duplicate rows or sending two APNS pushes. Worse: partial retries mean some side effects already happened, others did not.
+
+**Solution — idempotency keys persisted with unique constraint.** Every mutating operation accepts (or generates) an idempotency key. The first write wins; subsequent duplicates are no-ops.
+
+```sql
+-- Created inside each tenant's schema; no tenant_id column needed (schema itself isolates).
+CREATE TABLE {tenant_schema}.action_logs (
+    id UUID PRIMARY KEY,
+    idempotency_key UUID NOT NULL UNIQUE,
+    -- ... other columns
+);
+```
+
+```python
+# modules/action_resolver/db.py
+def create_action_log(self, input_: AssignActionInput, correlation_id: str) -> ActionLog:
+    key = input_.idempotency_key or correlation_id
+    with self._conn.cursor() as cur:
+        cur.execute(
+            f"""
+            INSERT INTO {self._schema}.action_logs (id, idempotency_key, ...)
+            VALUES (%s, %s, ...)
+            ON CONFLICT (idempotency_key) DO UPDATE
+                SET id = {self._schema}.action_logs.id  -- no-op trigger so we return existing row
+            RETURNING *;
+            """,
+            (uuid4(), key, ...),
+        )
+        return ActionLog.model_validate(dict(cur.fetchone()))
+```
+
+**Per-tenant uniqueness is automatic.** Because the table lives inside a tenant schema, the `UNIQUE (idempotency_key)` constraint scopes per-tenant for free. No cross-tenant collisions possible.
+
+**Who supplies the key.**
+- AppSync mutations: client passes an optional `idempotencyKey`. If absent, the resolver derives one from request id + tenant + logical operation (covers within-session dedup, not cross-session).
+- SQS consumers: use the SNS message id as the key (included in message attributes).
+- Internal Lambda → Lambda calls: use the caller's correlation id.
+
+**When NOT to use.** Pure reads (no side effects). Idempotency is a write-side concern.
+
+**Common mistakes:**
+- Using the client's retry id (AppSync request id) as the only idempotency key. Different clients can retry the "same logical action" with different ids — bad for user-facing dedup.
+- Making the key unique globally instead of per-tenant. You will collide across tenants, reject legitimate operations.
+- Implementing idempotency at the API layer (check-then-insert with a cache). It is racy — only the database `UNIQUE` constraint gives atomic guarantees.
+
+---
+
+## 10. Anti-Patterns to Avoid
+
+These have caused real bugs in similar systems. Catch them in review.
+
+| Anti-pattern | Why it hurts | What to do instead |
+|--------------|--------------|--------------------|
+| **God class / god file** (> 200 LOC, > 10 public methods) | Hides coupling, makes review and testing painful. | Split by concern per [code-standards.md §2.2](code-standards.md). |
+| **Deep inheritance** (3+ levels) | Behavior becomes hard to trace; framework magic proliferates. | Composition (pass collaborators as params) over inheritance. |
+| **Mocks in production code paths** (e.g., a `MockProvider` fallback imported in `handler.py`) | Test doubles ship to prod; production-vs-test drift. | Mocks live in `tests/`, period. Production code uses real providers or a feature flag. |
+| **Hidden coupling via module-level state** (module-level singletons, globals mutated from handlers) | Cold-start behavior differs from warm; impossible to unit-test in parallel. | Pass dependencies explicitly; if you need a cache, own its lifecycle in `config.py`. |
+| **Premature abstraction** (a `BaseService` class with one subclass) | Overhead with no payoff; locks in the wrong shape. | Wait for the second concrete use. Duplicate once, extract at N=2. |
+| **"Just in case" error handling** (catching every `Exception` at every layer) | Hides bugs; debugging becomes guessing. | Catch only at boundaries. Let unexpected exceptions surface. |
+| **Side effects in imports** (a `client = BotoClient()` at module top level) | Cold-start cost; testing any file instantiates clients. | Create in `config.py` or lazily inside a function. |
+| **String concatenation into SQL or GraphQL** | Injection, obviously, but also schema-drift bugs. | Parameterized everything ([code-standards.md §5.1](code-standards.md)). |
+
+---
+
+## 11. Tenant-per-Schema Isolation
+
+**Problem.** Row-level multi-tenancy (every table has `tenant_id`, every query has `WHERE tenant_id = %s`) puts the isolation invariant in developer discipline. One missing `WHERE` clause leaks data across tenants. Audits, backups, and per-tenant archiving are awkward.
+
+**Solution — one PostgreSQL schema per tenant.** Each tenant gets `tenant_{slug}` (e.g., `tenant_acme`, `tenant_fpt`). All business tables (devices, actions, chats, etc.) live inside the tenant schema. A separate `meta` schema holds tenant registry + shared enums.
+
+```
+postgres (single database)
+├── meta                      # Shared: tenants, platforms, message_templates (global)
+│   ├── tenants               # (id, slug, schema_name, created_at, ...)
+│   ├── platforms             # Seeded enum: apple, samsung, xiaomi, ...
+│   └── ...
+├── tenant_acme               # Per-tenant business data
+│   ├── devices
+│   ├── device_state_transitions
+│   ├── state_policies
+│   ├── action_logs
+│   ├── chats
+│   └── ...
+├── tenant_fpt
+│   └── (same tables as tenant_acme)
+└── ...
+```
+
+### 11.1 Schema-Qualified SQL (Mandatory)
+
+Every query uses `{tenant_schema}.<table>` — never an unqualified table name, never `SET search_path`.
+
+```python
+# Correct — explicit schema:
+cur.execute(f"SELECT * FROM {schema}.devices WHERE id = %s", (id,))
+
+# Wrong — implicit via search_path:
+cur.execute("SET search_path TO tenant_acme, public")
+cur.execute("SELECT * FROM devices WHERE id = %s", (id,))
+```
+
+Explicit beats implicit: the query read in isolation tells you which tenant it touches. `search_path` is connection-level state that pooled connections can leak across tenants.
+
+### 11.2 Schema Name Resolution
+
+The `tenant_schema` value flows:
+1. Client authenticates with Cognito — token carries `tenant_id` claim.
+2. Lambda auth decorator reads the claim, looks up `meta.tenants` to fetch `schema_name`.
+3. Resolved `tenant_schema` is passed into repositories at construction.
+4. Repositories f-string-interpolate it into SQL.
+
+**Schema name must be validated** before any f-string use: `re.fullmatch(r"tenant_[a-z0-9_]{1,40}", schema_name)`. Never accept `tenant_schema` from request arguments; only from the validated auth claim path.
+
+### 11.3 Migrations
+
+Alembic runs migrations against every tenant schema in sequence (and against `meta` for shared changes).
+
+- DDL migrations receive `tenant_schema` as a parameter, apply once per schema.
+- Data migrations (seeding FSM policies, for example) do the same.
+- A new tenant is created by cloning a **template schema** (`tenant_template`), which holds the current DDL baseline.
+
+### 11.4 When NOT to Use Tenant-per-Schema
+
+- Single-tenant deployments (internal tooling, POCs).
+- Very-high-cardinality tenancy (tens of thousands of tenants) where schema count becomes a PostgreSQL catalog bottleneck. Fluxion targets dozens of enterprise tenants, well within limits.
+
+### 11.5 Common Mistakes
+
+- Building a query string in Python and injecting `tenant_schema` without validation. Always validate with the regex in §11.2.
+- Sharing a pooled connection across tenants using `SET search_path`. Don't — pool connections with no per-tenant state, pass `tenant_schema` in SQL.
+- Forgetting to register the new table in the template schema. New DDL must go into `tenant_template` + every existing tenant schema (Alembic handles the latter).
+- Putting tenant-global data (message templates, TACs) inside a tenant schema. Global data belongs in `meta`.
+
+---
+
+## 12. Choosing Between Patterns (Cheat Sheet)
+
+| Problem | Pattern |
+|---------|---------|
+| Multi-Lambda command flow | Choreography Saga (§2) |
+| Branching device lifecycle | FSM (§3) |
+| GraphQL field → business logic | Resolver (§4) |
+| SQL spread through business code | Repository (§5) |
+| Multiple OEM integrations | Factory (§6) |
+| Bad data entering business logic | DTO / Pydantic (§7) |
+| External dependency flaking | Circuit Breaker (§8) |
+| Duplicate events / retries | Idempotency (§9) |
+
+If your problem is not in the table, solving it with a pattern is probably premature. Write the straight-line code first.
+
+---
+
+## 13. References
+
+- [code-standards.md](code-standards.md) — rules the patterns assume.
+- [module-structure.md](module-structure.md) — where patterns physically live in the repo.
+- [testing-guide.md](testing-guide.md) — how to test each pattern.
+- **Wiki T3** — FSM and Harel Statechart theory (deeper background for §3).
+- **Wiki T4** — System architecture (saga and resolver patterns visualized).
+- **Wiki T5** — DeviceFSM tables (schema the §3 pattern relies on).
+
+---
+
+## 14. Change Log
+
+| Version | Date | Change |
+|---------|------|--------|
+| v1.0 | 2026-04-19 | Initial release (#61). |

--- a/docs/module-structure.md
+++ b/docs/module-structure.md
@@ -1,0 +1,291 @@
+# Module Structure
+
+> **Version:** v1.0
+> **Audience:** Fluxion contributors scaffolding or reorganizing modules.
+> **Authority:** Source of truth for directory layout. Pairs with [code-standards.md](code-standards.md) (file naming) and [design-patterns.md](design-patterns.md) (intra-module patterns).
+> **Principles:** YAGNI — ship only dirs with real files. KISS — flat beats nested until it hurts.
+
+---
+
+## 1. Monorepo Top-Level
+
+```
+fluxion/
+├── fluxion-frontend/       React 19 SPA (admin console) — own terraform/
+├── fluxion-backend/        Python Lambda resolvers — own terraform/
+├── fluxion-oem/            Python Lambda workers for OEM integrations (APNS, future Samsung/Xiaomi) — own terraform/
+├── docs/                   Foundation docs (this document lives here)
+├── plans/                  Implementation plans + reports
+├── .github/                CI/CD workflows, PR templates, issue templates
+└── README.md               Entry point + quick start
+```
+
+**Rules:**
+
+- One language runtime per sub-repo. `fluxion-frontend/` is TypeScript only; `fluxion-backend/` and `fluxion-oem/` are Python only.
+- Cross-repo sharing happens through **contracts**, not imports: GraphQL schema, SQS event schemas (JSON Schema / Pydantic models re-declared per consumer), SSM parameters.
+- **Per-sub-repo IaC.** Each `fluxion-*` repo owns its own `terraform/` dir — deploys its own stack independently.
+- **No shared code dirs.** Each Lambda is self-contained; cross-cutting concerns (logging, auth decorators, error base classes) are copied per Lambda. Avoids coupling + deployment-order issues.
+- No root-level source files beyond `README.md`. Root is a workspace, not a module.
+
+---
+
+## 2. fluxion-backend (Python 3.12 Lambda + AppSync + Alembic)
+
+Backend hosts AppSync GraphQL resolvers and command-pipeline Lambdas that write to PostgreSQL.
+
+### 2.1 Top-Level Layout
+
+```
+fluxion-backend/
+├── modules/
+│   ├── device_resolver/          # Lambda package — AppSync resolver
+│   ├── action_resolver/          # Lambda package
+│   ├── upload_resolver/          # Lambda package
+│   ├── action_trigger/           # Lambda package — SNS → SQS dispatcher
+│   ├── checkin_handler/          # Lambda package — MDM check-in consumer
+│   ├── message_template_resolver/
+│   └── tac_resolver/
+├── terraform/                    # IaC — modules + environments (see §5)
+├── migrations/                   # Alembic environment
+│   ├── alembic.ini
+│   ├── env.py
+│   └── versions/
+│       ├── 0001_create_tenant_tables.py
+│       ├── 0042_add_tacs_table.py
+│       └── ...
+├── pyproject.toml                # Single root project; workspaces via tool.uv or tool.poetry groups
+└── README.md
+```
+
+### 2.2 Lambda Package Layout
+
+Each Lambda function is a Python package. Directory name **must be snake_case** to satisfy AWS Lambda handler import resolution (see [code-standards.md §2.1](code-standards.md#21-file-naming)).
+
+```
+fluxion-backend/modules/device_resolver/
+├── __init__.py
+├── handler.py                    # Lambda entry (≤ 50 LOC)
+├── config.py                     # Env var parsing, constants
+├── helpers.py                    # Module-local utilities
+├── db.py                         # Data access (psycopg2 / SQLAlchemy)
+├── errors.py                     # Domain errors (FluxionError subclasses)
+├── pyproject.toml                # Per-Lambda dependencies
+├── Dockerfile                    # Container image (inherits from Dockerfile.resolver)
+└── tests/
+    ├── __init__.py
+    ├── conftest.py
+    └── test_*.py
+```
+
+**Rules:**
+
+- `handler.py` ≤ 50 LOC. Parse event → Pydantic → delegate → serialize. No business logic.
+- One logical concern per file. Split when a file crosses 200 LOC (see §2.3).
+- Each Lambda is **self-contained** — no imports from sibling modules. Copy common utilities when needed; rely on AWS Lambda Layers or post-build bundling only if duplication becomes painful (document the exception).
+- Tests live inside the Lambda package in `tests/` — colocated, not in a sibling tree. Self-contained packaging (exclude `tests/` via Dockerfile / zip).
+- `__init__.py` stays empty unless re-exporting intentional public API.
+
+### 2.3 When to Split a File
+
+| Trigger | Action |
+|---------|--------|
+| File > 200 LOC | Split by concern (queries vs mutations, read vs write, public vs internal). |
+| Two distinct responsibilities in one file | Split even under 200 LOC. |
+| Circular import detected | Break the cycle by moving the shared type into the consumer that makes more semantic sense, or duplicate the definition (since each Lambda is self-contained). |
+
+---
+
+## 3. fluxion-oem (Python 3.12 — OEM worker Lambdas)
+
+OEM workers consume SQS events and talk to vendor-specific APIs (Apple APNS today; Samsung Knox, Xiaomi in future).
+
+### 3.1 Top-Level Layout
+
+```
+fluxion-oem/
+├── modules/
+│   └── apple_process_action/     # Lambda package — Apple MDM / APNS worker
+├── terraform/                    # IaC — modules + environments (see §5)
+├── pyproject.toml
+└── README.md
+```
+
+Lambda package layout identical to backend (see §2.2). Additional OEM providers (Samsung Knox, Xiaomi) will be new sibling packages under `modules/`.
+
+---
+
+## 4. fluxion-frontend (React 19 + TypeScript 5.x + Vite + Tailwind 4)
+
+Admin console for tenant operators. Feature-based organization, Amplify v6 for GraphQL calls.
+
+### 4.1 Top-Level Layout
+
+```
+fluxion-frontend/
+├── src/
+│   ├── features/                     # Business features (primary organization)
+│   │   ├── devices/
+│   │   ├── actions/
+│   │   ├── chat/
+│   │   ├── message-templates/
+│   │   └── tacs/
+│   ├── components/
+│   │   └── ui/                       # shadcn/ui primitives (Button, Dialog, Table)
+│   ├── hooks/                        # Cross-feature hooks only
+│   ├── lib/                          # Cross-feature utilities (format-date.ts, api-client.ts)
+│   ├── services/                     # API gateway, Amplify client wrapper
+│   ├── types/                        # Shared types (generated from GraphQL schema)
+│   ├── routes/                       # TanStack Router route tree
+│   ├── App.tsx
+│   └── main.tsx
+├── public/
+├── terraform/
+├── tests/
+│   └── e2e/                          # Playwright E2E tests
+├── tsconfig.json                     # "@/*" → "./src/*"
+├── vite.config.ts                    # alias mirror of tsconfig paths
+├── tailwind.config.ts
+├── package.json
+└── README.md
+```
+
+### 4.2 Feature Module Layout
+
+```
+fluxion-frontend/src/features/devices/
+├── components/
+│   ├── DeviceTable.tsx               # PascalCase — React component
+│   ├── DeviceDetailPanel.tsx
+│   └── EnrollmentForm.tsx
+├── hooks/
+│   ├── use-device-list.ts            # kebab-case — hook
+│   └── use-enrollment-mutation.ts
+├── services/
+│   └── device-service.ts             # API calls wrapping Amplify client
+├── types/
+│   └── device-types.ts               # feature-local types (exports are PascalCase)
+├── __tests__/
+│   ├── DeviceTable.test.tsx
+│   └── use-device-list.test.ts
+└── index.ts                          # Public exports only (what other features may import)
+```
+
+### 4.3 Import Rules
+
+- **Always via alias.** `import { DeviceTable } from "@/features/devices";` — never `"../../features/devices"`.
+- **Cross-feature imports go through `index.ts`.** Deep imports (`@/features/devices/components/DeviceTable`) are forbidden — they bypass the public contract.
+- **Shared code in `lib/` or `components/ui/`** is fair game from anywhere.
+- **No circular feature deps.** If `features/actions` needs `features/devices`, extract the shared piece to `lib/` or `types/`.
+
+---
+
+## 5. terraform/ (Per-Sub-Repo IaC)
+
+Each `fluxion-*` repo owns its own `terraform/` directory. No monorepo-root IaC. Cross-stack dependencies flow through **SSM parameters** (or remote state data sources), not shared code.
+
+### 5.1 Per-Repo Scope
+
+| Repo | Terraform owns |
+|------|---------------|
+| `fluxion-backend/terraform/` | AppSync API, RDS + Proxy, Cognito, Lambda resolvers (ECR repos), SNS/SQS for command pipeline |
+| `fluxion-oem/terraform/` | OEM worker Lambdas (ECR repos), SQS consumer queues, APNS secret rotation |
+| `fluxion-frontend/terraform/` | CloudFront, S3 static hosting, WAF, ACM cert, Route53 record |
+
+Shared primitives (VPC, base networking, IAM roles) live in whichever repo boots them **first** (typically `fluxion-backend`); other repos consume via `data "aws_ssm_parameter"` or `data "terraform_remote_state"`.
+
+### 5.2 Layout (applies to every sub-repo's `terraform/`)
+
+```
+<sub-repo>/terraform/
+├── modules/
+│   ├── <module-name>/                # Reusable module
+│   │   ├── main.tf                   # Resource declarations
+│   │   ├── variables.tf              # Typed inputs
+│   │   ├── outputs.tf                # Exported values
+│   │   ├── locals.tf                 # Computed values
+│   │   ├── versions.tf               # Provider + terraform version pinning
+│   │   └── README.md                 # Inputs / Outputs / Example usage
+│   └── ...
+├── envs/
+│   ├── dev/
+│   │   ├── main.tf                   # Module wiring
+│   │   ├── backend.tf                # S3 + DynamoDB lock config
+│   │   └── terraform.tfvars          # Env-specific values
+│   ├── staging/
+│   └── prod/
+└── README.md
+```
+
+### 5.3 Rules
+
+- **Modules are reusable; environments wire them.** A module does not know which environment it runs in.
+- **No hardcoded account IDs or region literals** inside modules — pass as variables.
+- **State backends are per-environment**, locked via DynamoDB. Each sub-repo uses its own state bucket path (`s3://fluxion-tf-state/<repo>/<env>/`).
+- **Cross-repo dependencies via SSM:** producing repo writes an `aws_ssm_parameter`; consuming repo reads via `data "aws_ssm_parameter"`. Never share Terraform state.
+- **`main.tf` > 300 LOC** → split by resource category (`iam.tf`, `networking.tf`) or extract a sub-module.
+- **README required** on every module. Use `terraform-docs` to auto-generate Inputs/Outputs tables.
+
+---
+
+## 6. Cross-Stack Contracts
+
+When two sub-repos must agree on a shape, the contract lives outside both:
+
+| Contract | Location | Consumer |
+|----------|----------|----------|
+| GraphQL schema | `fluxion-backend/schema.graphql` (root of backend repo) | Frontend codegen input |
+| SQS event payloads | Re-declared as Pydantic models inside each consuming Lambda's `dto.py` | OEM workers, checkin_handler |
+| SSM parameters | Written by producing repo's Terraform; read via `data "aws_ssm_parameter"` | Other sub-repos' Terraform (cross-stack wiring) |
+| Lambda env vars | `<sub-repo>/terraform/modules/<lambda>/variables.tf` | Lambda runtime via `os.environ` |
+
+**Rule:** when a contract changes, update it in one place first, then update consumers in a separate commit. Never co-mingle contract change with consumer change — makes review and rollback harder.
+
+**No `shared/` module.** SQS event schemas are intentionally duplicated across consumers — each Lambda owns its own DTO definition. Schema drift is caught by contract tests (see [testing-guide.md](testing-guide.md)), not by a shared import.
+
+---
+
+## 7. File Size Enforcement
+
+| File type | Max LOC | When over limit |
+|-----------|---------|-----------------|
+| Python module (non-handler) | 200 | Split by concern. |
+| Python Lambda `handler.py` | 50 | Extract to sibling module. |
+| React component | 150 | Extract sub-components or custom hook. |
+| React hook | 100 | Extract helper utilities. |
+| Terraform `main.tf` | 300 | Split by resource category or extract sub-module. |
+| Tests | 300 | Split by behavior group. |
+| Markdown docs | 800 | Split by topic (current file already under this limit). |
+
+LOC counted excludes blank lines, imports, and top-level docstrings.
+
+---
+
+## 8. When to Deviate
+
+Structure rules exist to reduce churn, not to gatekeep. Deviate when **documented** in a PR description:
+
+- Prototyping a new Lambda? A single `handler.py` > 50 LOC is fine during spike — note intent to split before merge.
+- One-off script that does not import anywhere else? Flat `scripts/` dir at sub-repo root is fine.
+- Experimental OEM integration? Temporary `experimental/` dir within `fluxion-oem/modules/` is acceptable until graduated.
+
+Deviations must not leak into tests or contracts — those follow the rules strictly.
+
+---
+
+## 9. References
+
+- [code-standards.md](code-standards.md) — file naming, general rules.
+- [design-patterns.md](design-patterns.md) — intra-module patterns (resolver, repository, factory).
+- [testing-guide.md](testing-guide.md) — test file placement.
+- **Wiki T4** — System architecture design (module boundaries visualized).
+- **Wiki T5** — API contract and ER diagram (informs schema and migration layout).
+- Research: [researcher-260419-1545-file-naming-conventions-2026.md](../plans/reports/researcher-260419-1545-file-naming-conventions-2026.md).
+
+---
+
+## 10. Change Log
+
+| Version | Date | Change |
+|---------|------|--------|
+| v1.0 | 2026-04-19 | Initial release (#61). |

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -1,0 +1,347 @@
+# Testing Guide
+
+> **Version:** v1.0
+> **Audience:** Fluxion contributors writing or reviewing tests.
+> **Authority:** How Fluxion tests. Pairs with [code-standards.md](code-standards.md) (rules), [module-structure.md](module-structure.md) (test file placement), [design-patterns.md](design-patterns.md) (what to test per pattern).
+> **Principles:** A failing test is a bug. A flaky test is a bigger bug. A missing test is a future bug.
+
+---
+
+## 1. Introduction
+
+Fluxion handles real customer devices on real payment plans. A regression that locks the wrong phone, a migration that drops a tenant's data, or an auth decorator that leaks across tenants — any of these is unacceptable. Tests are the primary defense.
+
+This guide defines the test pyramid, naming, fixtures, coverage, and CI gates. Every contributor follows it; every PR cites it when adding or changing tests.
+
+---
+
+## 2. Test Pyramid
+
+| Layer | Share | Scope | Typical runtime |
+|-------|-------|-------|-----------------|
+| Unit | 70% | Single module or function, no I/O | < 100 ms each |
+| Integration | 25% | Lambda + real dependencies (DB, LocalStack, moto) | < 5 s each |
+| E2E | 5% | Full stack from frontend → AppSync → DB | < 60 s each |
+
+**Keep the pyramid shape.** Inverted pyramids (most integration, few units) are slow, flaky, and expensive. If integration tests start duplicating unit-level logic, move the logic back to unit tests.
+
+---
+
+## 3. Python Tests (Pytest)
+
+### 3.1 Placement and Naming
+
+- Tests live **inside the Lambda package** at `modules/<name>/tests/`, matching the package layout (see [module-structure.md §2.2](module-structure.md)).
+- File naming: `test_<module_under_test>.py` (e.g., `test_db.py`, `test_handler.py`).
+- Function naming: `test_<scenario>_<expected>` — imperative, present tense, action-oriented.
+
+```
+modules/device_resolver/
+├── handler.py
+├── db.py
+├── dto.py
+└── tests/
+    ├── __init__.py
+    ├── conftest.py
+    ├── test_handler.py
+    ├── test_db.py
+    └── test_dto.py
+```
+
+**Examples:**
+
+```python
+def test_enroll_device_returns_registered_state(...): ...
+def test_enroll_device_raises_conflict_when_serial_duplicate(...): ...
+def test_handler_rejects_unknown_field(...): ...
+```
+
+Do not prefix with the class name (`test_DeviceRepository_enroll`) — the file name already scopes it.
+
+### 3.2 AAA Pattern
+
+Arrange / Act / Assert, with blank-line separators. Comments optional, separators mandatory.
+
+```python
+def test_enroll_device_returns_registered_state(repo, tenant_schema):
+    # Arrange
+    serial = "F2LZK9H8LMNA"
+
+    # Act
+    device = repo.enroll(serial, Platform.APPLE)
+
+    # Assert
+    assert device.state == DeviceState.REGISTERED
+    assert device.serial == serial
+```
+
+One behavior per test. If the "Assert" block checks three unrelated properties, split into three tests.
+
+### 3.3 Fixtures
+
+- `conftest.py` lives in every Lambda's `tests/` dir.
+- Prefer **factories** (`factory-boy`, or plain factory functions) over JSON fixture files. Factories are typed, discoverable, composable.
+- Shared fixtures **do not cross Lambda boundaries** — each Lambda's `conftest.py` is independent. Duplication is acceptable (see [design-patterns.md §1](design-patterns.md)).
+
+```python
+# modules/device_resolver/tests/conftest.py
+import pytest
+from device_resolver.dto import Device, Platform, DeviceState
+
+@pytest.fixture
+def registered_device_factory(tenant_schema):
+    def _make(**overrides):
+        defaults = dict(
+            tenant_schema=tenant_schema,
+            serial="F2LZK9H8LMNA",
+            platform=Platform.APPLE,
+            state=DeviceState.REGISTERED,
+        )
+        return Device(**{**defaults, **overrides})
+    return _make
+```
+
+### 3.4 Mocking Policy
+
+**Mock at the boundary. Never in the middle.**
+
+| Layer | Mock? |
+|-------|-------|
+| AWS SDK calls (`boto3`) | Yes — via `moto` or local fakes. |
+| HTTP to external APIs (APNS, OEM) | Yes — via `respx` / `httpx_mock`. |
+| PostgreSQL driver | No. Use a real DB (testcontainers) — see §4. |
+| Own repository / service classes | No. These are what you are testing. |
+| Pydantic models | No. Real models; they are value objects. |
+
+Violations of this policy cause most false-pass incidents: a test that mocks the repository passes while the real SQL is broken. Don't.
+
+### 3.5 Parametrize Edge Cases
+
+Use `@pytest.mark.parametrize` when the same behavior has many inputs — state transitions, policy matrices, boundary values.
+
+```python
+@pytest.mark.parametrize("from_state,action,expected_to_state", [
+    (DeviceState.REGISTERED, "enroll", DeviceState.ENROLLED),
+    (DeviceState.ENROLLED,   "lock",   DeviceState.LOCKED),
+    (DeviceState.LOCKED,     "unlock", DeviceState.ACTIVE),
+])
+def test_fsm_transition_happy_path(from_state, action, expected_to_state, repo):
+    ...
+```
+
+One matrix beats ten near-duplicate tests.
+
+### 3.6 Testing `config.py`
+
+Because `config.py` reads `os.environ` at import time, tests must set env vars **before** importing the module under test.
+
+```python
+# tests/conftest.py
+import os
+import pytest
+
+@pytest.fixture(autouse=True, scope="session")
+def _set_env():
+    os.environ.setdefault("ACTION_TRIGGER_SQS", "arn:aws:sqs:...:test-queue")
+    os.environ.setdefault("ACTION_ASSIGNED_TOPIC", "arn:aws:sns:...:test-topic")
+    os.environ.setdefault("DB_SECRET_ARN", "arn:aws:secretsmanager:...:test")
+    os.environ.setdefault("LOG_LEVEL", "DEBUG")
+    yield
+```
+
+For tests that exercise "env var is missing" behavior, use `monkeypatch.delenv` + `importlib.reload(config)` inside the test.
+
+---
+
+## 4. Integration Tests
+
+Integration tests exercise a Lambda against real (or in-container) dependencies: PostgreSQL, SNS, SQS, S3.
+
+### 4.1 PostgreSQL — Testcontainers
+
+- Always a **real PostgreSQL 15+ container**, never SQLite. Production parity matters for schemas, JSONB, `ON CONFLICT`, `RETURNING`.
+- Startup once per test **session**, torn down at the end.
+- Each test creates its own tenant schema (via the schema-creation helper), runs, drops it.
+
+```python
+# tests/integration/conftest.py
+import pytest
+from testcontainers.postgres import PostgresContainer
+
+@pytest.fixture(scope="session")
+def pg_container():
+    with PostgresContainer("postgres:15-alpine") as pg:
+        # Apply base schema + meta + tenant_template
+        apply_migrations(pg.get_connection_url())
+        yield pg
+
+@pytest.fixture
+def tenant_schema(pg_container, request):
+    name = f"tenant_test_{request.node.name[:30]}"
+    create_tenant_schema(pg_container, name)  # clone from tenant_template
+    yield name
+    drop_tenant_schema(pg_container, name)
+```
+
+This gives every test a fresh schema, structurally isolated, torn down at test end.
+
+### 4.2 AWS Services — Moto / LocalStack
+
+- `moto` for SNS, SQS, S3, Secrets Manager, Parameter Store — fast, in-process, good enough for most flows.
+- `LocalStack` only when a moto gap blocks you (e.g., AppSync flows, EventBridge rules). More heavyweight, slower.
+- **Never mock Cognito.** Either use the real Cognito (staging pool) in an E2E test, or stub the auth decorator at the `TenantContext` boundary in a unit test.
+
+### 4.3 Teardown
+
+Transactional rollback > DB wipe. When possible, wrap each integration test in a savepoint and roll it back. When schema-level DDL is involved (e.g., tenant schema creation), drop the schema in teardown — still faster than recreating the whole database.
+
+### 4.4 SQS / SNS Contract Tests
+
+Per [module-structure.md §6](module-structure.md), SQS payloads are **duplicated** across consumers. Every producer and every consumer of an event type owns a contract test that asserts the payload it emits / consumes matches the schema.
+
+```python
+# In each consumer's tests/:
+def test_consumes_action_assigned_v1(sample_sns_record):
+    event = ActionAssigned.model_validate_json(sample_sns_record.body)
+    assert event.version == "1"
+    # ... further assertions
+```
+
+Shared JSON fixture files (`sample_action_assigned_v1.json`) live in each consuming Lambda, version-tagged. When a producer bumps the version, every consumer's contract test fails until updated — drift becomes visible.
+
+---
+
+## 5. TypeScript Tests (Vitest + React Testing Library)
+
+### 5.1 Placement and Naming
+
+- Component tests: next to the component, `DeviceTable.test.tsx`.
+- Hook tests: next to the hook, `use-device-list.test.ts`.
+- Feature-level tests: in `__tests__/` inside the feature dir.
+
+### 5.2 React Testing Library Queries
+
+Prefer queries that match how users find elements:
+
+1. `getByRole` + `name` — best for buttons, headings, form fields.
+2. `getByLabelText` — form inputs.
+3. `getByText` — non-interactive content.
+4. `getByTestId` — last resort; only when semantic queries fail.
+
+```tsx
+// Do
+await user.click(screen.getByRole("button", { name: /enroll device/i }));
+
+// Don't
+await user.click(screen.getByTestId("enroll-button"));
+```
+
+### 5.3 API Mocking via MSW
+
+Use Mock Service Worker (MSW) for GraphQL / HTTP. Intercepts at the network boundary — components under test exercise the real Amplify client.
+
+```ts
+// tests/msw/handlers.ts
+export const handlers = [
+  graphql.query("ListDevices", () => HttpResponse.json({ data: { listDevices: [...] }})),
+];
+```
+
+No `any`, no `@ts-ignore` in tests — strict TypeScript applies to test files too.
+
+---
+
+## 6. Coverage Targets
+
+| Scope | Target | Enforcement |
+|-------|--------|-------------|
+| Backend global (line + branch) | ≥ 80% | `pytest --cov --cov-fail-under=80` in CI |
+| Frontend global | ≥ 80% | `vitest run --coverage` with threshold |
+| Critical paths | **100%** | Manual review per PR (see §6.1) |
+| Handler entry (`handler.py`) | Excluded | Tested via integration tests only |
+
+### 6.1 Critical Paths Requiring 100% Coverage
+
+These paths break production in ways that damage customer trust or data. No PR touching them merges with coverage < 100%:
+
+- Auth decorators (`require_role`, `tenant_scoped`).
+- FSM transitions (`apply_action` and all policy evaluations).
+- Idempotency write paths (every `ON CONFLICT` insert).
+- Schema-name validation regex + any f-string-interpolated SQL.
+- Migrations (every up and down path runs in integration tests against a fresh DB).
+- Frontend auth guard routes.
+
+### 6.2 What NOT to Test
+
+Testing these is noise:
+
+- Third-party library behavior (trust pytest, moto, pydantic, React).
+- Framework glue (AppSync routing, Vite HMR).
+- Trivial getters/setters that only return a field.
+- Generated code (GraphQL codegen output).
+
+Write a test only if it would catch a realistic regression in **your** code.
+
+---
+
+## 7. Test Data
+
+- **Factories over fixtures.** Typed, composable, discoverable. `factory-boy` for Python; hand-written factory functions for TypeScript.
+- **No hardcoded JSON fixture files** except for contract-test samples (§4.4), which are versioned and owned.
+- **Every test creates its own tenant schema.** No shared test DB state; no "setup data" that later tests depend on.
+- **Use realistic but non-PII data.** Fake serials (`F2LZK9H8LMNA`), tenant slugs (`test_acme`), email domains (`@test.fluxion.local`).
+
+---
+
+## 8. CI Requirements
+
+| Requirement | Enforcement |
+|-------------|-------------|
+| All tests pass | CI job blocks merge. |
+| Coverage thresholds met | `pytest` / `vitest` fail below target. |
+| No flaky tests | One retry only for known-flaky markers; persistent flakes are P0 bugs. |
+| Parallel execution | `pytest-xdist -n auto` / Vitest thread pool. |
+| Fail-fast on first failure (CI only) | `-x` flag. Locally, run full suite. |
+| JUnit XML + coverage uploaded | For PR annotations + Codecov. |
+
+No `--no-verify` / hook skip unless reviewer explicitly approves.
+
+---
+
+## 9. Test Review Checklist (PRs)
+
+Reviewer and author tick the checklist. If an item cannot be ticked, explain in the PR body.
+
+- [ ] AAA pattern with blank-line separators.
+- [ ] No commented-out tests.
+- [ ] No `time.sleep` — use deterministic synchronization (event loop fixtures, mocked clocks).
+- [ ] Every critical path (§6.1) touched has 100% coverage.
+- [ ] Integration tests use real PostgreSQL via testcontainers, not SQLite.
+- [ ] Mocks only at boundaries (see §3.4).
+- [ ] Factories, not JSON fixtures (except contract-test samples).
+- [ ] Each test creates its own tenant schema; no shared state.
+- [ ] Env vars set via `conftest.py`, not hardcoded inside tests.
+- [ ] No `any` / `@ts-ignore` in TS tests.
+- [ ] Test function names read as sentences (`test_<scenario>_<expected>`).
+
+---
+
+## 10. References
+
+- [code-standards.md](code-standards.md) — rules tests must follow.
+- [module-structure.md](module-structure.md) — where test files live.
+- [design-patterns.md](design-patterns.md) — patterns tests validate (esp. §11 tenant-per-schema).
+- Pytest docs — https://docs.pytest.org/
+- Testcontainers Python — https://testcontainers-python.readthedocs.io/
+- Moto — https://docs.getmoto.org/
+- Vitest — https://vitest.dev/
+- React Testing Library — https://testing-library.com/docs/react-testing-library/intro/
+- MSW — https://mswjs.io/
+
+---
+
+## 11. Change Log
+
+| Version | Date | Change |
+|---------|------|--------|
+| v1.0 | 2026-04-19 | Initial release (#61). |


### PR DESCRIPTION
## Summary

Single commit that introduces the 4 foundation docs (plus `.gitignore`) codifying conventions before Phase 3 (#29+) implementation.

- **`docs/code-standards.md`** — naming per stack, file size, comments, error handling, logging, security; Python 3.12 + Ruff + `mypy --strict`; TypeScript 5 strict; SQL via SQLAlchemy 2.0 `text()` + named params; git workflow (`[#N]:` commits, branch-per-ticket `feature/N-slug`, commit-per-phase, PR-to-`develop`); 15 tooling-target CI gates declared.
- **`docs/module-structure.md`** — monorepo layout (3 sub-repos, per-sub-repo `terraform/`), Lambda package `src/` layout with `pythonpath = ["src"]` (imports without `src.` prefix), self-contained Lambdas (no shared code dirs), feature-based frontend organisation, cross-stack contracts via SSM.
- **`docs/design-patterns.md`** — 8 patterns (Choreography Saga, DB-driven FSM, Resolver, Repository, Factory for OEM, DTO/Pydantic inline — no `dto.py`, Circuit Breaker, Idempotency). Tenant-per-schema isolation with explicit `{schema}.table` SQL and `Connection.get_schema_name` via `public.t_tenant_schema_mapping`.
- **`docs/testing-guide.md`** — pyramid 70/25/5, testcontainers for real PostgreSQL, tenant schema per test (clone from `tenant_template`), 100% coverage on critical paths (auth, FSM, idempotency, migrations), Vitest + RTL + MSW for frontend, CI gates.
- **`.gitignore`** — `plans/` local only, standard Python / Node / Terraform / macOS exclusions.

Consolidates the content previously landed as `c6092c5` ([#61]: foundation docs) + `73873cc` ([chore]: branch-per-ticket workflow, closed PR #62) into one squashed commit for a clean GitFlow-style history on `develop`.

## Plan

`plans/260419-1524-foundation-docs-61/plan.md` (local only; not part of repo).

## Docs citations

- Self — this PR establishes the standards the PR itself follows.

## Test plan

- [x] All 4 docs under 800 LOC
- [x] 100% English, 0 Vietnamese
- [x] Cross-links between docs use relative paths and resolve
- [x] Wiki references (T2–T5) by section number, no dead URLs
- [x] `code-standards.md` §6.1–6.5 fully describes the `[#N]:` commit + `feature/N-slug` branch + PR flow this PR uses
- [ ] Reviewer confirms wording aligns with intended strictness (Ruff `select ALL`, mypy `--strict`, etc.)

Closes #61