### PR TITLE
[#30]: Terraform network + database modules (dev env)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,19 @@ bun run build            # production build
 
 ### Terraform (per sub-repo)
 
+Each sub-repo owns its IaC. Modules are reusable; environments wire them via SSM cross-stack reads.
+
 ```bash
 cd fluxion-backend/terraform/bootstrap
 terraform init && terraform apply -var=resource_name_prefix=fluxion-backend
 
 cd ../envs/dev
 terraform init -backend-config="bucket=<from_bootstrap>"
+terraform apply
 ```
+
+**Core modules** (detailed in [docs/module-structure.md §5](docs/module-structure.md#54-existing-modules)):
+- `modules/network` — VPC, subnets, fck-nat (t4g.nano), security groups; outputs to SSM for cross-repo use ([#30])
 
 ## Commit Convention
 

--- a/docs/module-structure.md
+++ b/docs/module-structure.md
@@ -205,6 +205,7 @@ Shared primitives (VPC, base networking, IAM roles) live in whichever repo boots
 │   │   ├── outputs.tf                # Exported values
 │   │   ├── locals.tf                 # Computed values
 │   │   ├── versions.tf               # Provider + terraform version pinning
+│   │   ├── <component>.tf            # Split large main.tf by resource category
 │   │   └── README.md                 # Inputs / Outputs / Example usage
 │   └── ...
 ├── envs/
@@ -225,6 +226,29 @@ Shared primitives (VPC, base networking, IAM roles) live in whichever repo boots
 - **Cross-repo dependencies via SSM:** producing repo writes an `aws_ssm_parameter`; consuming repo reads via `data "aws_ssm_parameter"`. Never share Terraform state.
 - **`main.tf` > 300 LOC** → split by resource category (`iam.tf`, `networking.tf`) or extract a sub-module.
 - **README required** on every module. Use `terraform-docs` to auto-generate Inputs/Outputs tables.
+
+### 5.4 Existing Modules
+
+#### `fluxion-backend/terraform/modules/network` ([#30])
+
+Provisions the core networking layer for Fluxion environments. Managed by a single environment (`envs/dev`); others inherit via SSM cross-stack reads.
+
+**Resources:**
+- VPC + DNS hostnames (default `10.0.0.0/16`)
+- 2 public + 2 private subnets (one pair per AZ, 2 AZs fixed)
+- Internet Gateway + public route table
+- **fck-nat** ARM instance (t4g.nano, ~$3/mo) with static ENI + EIP as NAT replacement (vs. $32/mo AWS-managed NAT Gateway)
+- Private route table routing outbound traffic through NAT ENI
+- 3 security groups: Lambda → RDS Proxy → RDS ingress chain
+
+**SSM exports:** `/fluxion/{env}/network/{vpc-id, vpc-cidr, public/private-subnet-ids, lambda-sg-id, rds-sg-id, rds-proxy-sg-id, nat-eip}`
+
+**Sub-files:**
+- `networking.tf` — VPC, subnets, route tables, IGW
+- `nat.tf` — fck-nat instance, ENI, EIP, ASG
+- `security-groups.tf` — Lambda, RDS Proxy, RDS SGs and ingress rules
+
+**Example usage:** See module README (envs/dev wires it; see Phase 3 of [#30]).
 
 ---
 
@@ -278,6 +302,7 @@ Deviations must not leak into tests or contracts — those follow the rules stri
 - [code-standards.md](code-standards.md) — file naming, general rules.
 - [design-patterns.md](design-patterns.md) — intra-module patterns (resolver, repository, factory).
 - [testing-guide.md](testing-guide.md) — test file placement.
+- `fluxion-backend/terraform/modules/network/README.md` — network module design (VPC, subnets, fck-nat).
 - **Wiki T4** — System architecture design (module boundaries visualized).
 - **Wiki T5** — API contract and ER diagram (informs schema and migration layout).
 - Research: [researcher-260419-1545-file-naming-conventions-2026.md](../plans/reports/researcher-260419-1545-file-naming-conventions-2026.md).
@@ -288,4 +313,5 @@ Deviations must not leak into tests or contracts — those follow the rules stri
 
 | Version | Date | Change |
 |---------|------|--------|
+| v1.1 | 2026-04-20 | Document Terraform modules section (§5.4); add network module reference (#30). |
 | v1.0 | 2026-04-19 | Initial release (#61). |

--- a/fluxion-backend/terraform/envs/dev/README.md
+++ b/fluxion-backend/terraform/envs/dev/README.md
@@ -8,33 +8,102 @@
 
 ## Initialise with remote backend
 
-Substitute `<state_bucket>` with the `state_bucket` output from bootstrap:
+Substitute `<state_bucket>` with the `state_bucket` output from bootstrap
+(current value: `fluxion-backend-tfstate`):
 
-```
+```bash
 terraform init -backend-config="bucket=<state_bucket>"
+```
+
+To force re-initialisation (e.g. after provider updates):
+
+```bash
+terraform init -reconfigure -backend-config="bucket=<state_bucket>"
 ```
 
 ## Plan and apply
 
-```
-terraform plan -var-file=terraform.tfvars
-terraform apply -var-file=terraform.tfvars
+```bash
+cp terraform.tfvars.example terraform.tfvars
+# edit terraform.tfvars as needed
+
+terraform validate
+terraform plan -out=tfplan
+terraform apply tfplan
 ```
 
 ## Variable file
 
 Copy the example and fill in real values:
 
-```
+```bash
 cp terraform.tfvars.example terraform.tfvars
 ```
 
 **Important:** `terraform.tfvars` contains environment-specific values and must be kept
 local — never commit it to version control. It is already listed in the root `.gitignore`.
 
+## Cost estimate
+
+| Component | Monthly cost |
+|---|---|
+| RDS db.t3.micro (free-tier eligible first 12 months) | ~$0 / ~$15 after |
+| fck-nat t4g.nano NAT instance | ~$3-4 |
+| Secrets Manager secret | ~$0.40 |
+| SSM Parameters (Standard tier) | free |
+| **Total (enable_rds_proxy=false)** | **~$4-5/mo** |
+
+Setting `enable_rds_proxy=true` adds ~$22/mo — keep false for dev.
+
+## SSM Parameter Contract
+
+All parameters are published under the prefix `/fluxion/{env}/`.
+
+| Parameter path | Type | Source |
+|---|---|---|
+| `/fluxion/dev/network/vpc-id` | String | `module.network.vpc_id` |
+| `/fluxion/dev/network/private-subnet-ids` | StringList | `module.network.private_subnet_ids` |
+| `/fluxion/dev/network/public-subnet-ids` | StringList | `module.network.public_subnet_ids` |
+| `/fluxion/dev/network/lambda-sg-id` | String | `module.network.lambda_sg_id` |
+| `/fluxion/dev/rds/endpoint` | String | `module.database.effective_endpoint` (hostname only) |
+| `/fluxion/dev/rds/port` | String | `module.database.db_port` |
+| `/fluxion/dev/rds/secret-arn` | String | `module.database.secret_arn` |
+
+### Consumer pattern (OEM processor / Lambda)
+
+Use `data "aws_ssm_parameter"` to read values without hard-coding:
+
+```hcl
+data "aws_ssm_parameter" "vpc_id" {
+  name = "/fluxion/dev/network/vpc-id"
+}
+
+data "aws_ssm_parameter" "private_subnet_ids" {
+  name = "/fluxion/dev/network/private-subnet-ids"
+}
+
+data "aws_ssm_parameter" "rds_secret_arn" {
+  name            = "/fluxion/dev/rds/secret-arn"
+  with_decryption = false  # ARN is not encrypted, just a string
+}
+```
+
+## Destroy warning
+
+**Always destroy the dev environment when not in use to avoid unnecessary AWS charges.**
+
+```bash
+terraform destroy
+```
+
+RDS has a final snapshot skipped (`skip_final_snapshot = true` in dev) so destroy completes
+without manual snapshot cleanup. Run destroy at the end of each dev session.
+
 ## Notes
 
-- `main.tf` is intentionally empty in scaffold ticket #29. Module wiring is added in
-  tickets #30 (network + database), #31 (migrations), #32 (Cognito + CI/CD).
+- Module wiring added in ticket #30 (network + database). Further modules (#31 migrations,
+  #32 Cognito + CI/CD, #33 AppSync) will extend `main.tf`.
 - State is stored remotely in S3 with S3-native locking (`use_lockfile = true`).
   No DynamoDB table is required.
+- `effective_endpoint` resolves to the RDS proxy endpoint when `enable_rds_proxy=true`,
+  otherwise the direct RDS instance address. Always use SSM to read this — never hard-code.

--- a/fluxion-backend/terraform/envs/dev/main.tf
+++ b/fluxion-backend/terraform/envs/dev/main.tf
@@ -11,9 +11,88 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.70"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
   }
 }
 
 provider "aws" {
   region = var.aws_region
+}
+
+module "network" {
+  source               = "../../modules/network"
+  resource_name_prefix = var.resource_name_prefix
+  env                  = var.env
+}
+
+module "database" {
+  source               = "../../modules/database"
+  resource_name_prefix = var.resource_name_prefix
+  env                  = var.env
+  private_subnet_ids   = module.network.private_subnet_ids
+  rds_sg_id            = module.network.rds_sg_id
+  rds_proxy_sg_id      = module.network.rds_proxy_sg_id
+  enable_rds_proxy     = var.enable_rds_proxy
+}
+
+locals {
+  ssm_prefix = "/fluxion/${var.env}"
+
+  ssm_tags = {
+    Project   = "fluxion"
+    Env       = var.env
+    ManagedBy = "terraform"
+  }
+}
+
+resource "aws_ssm_parameter" "vpc_id" {
+  name  = "${local.ssm_prefix}/network/vpc-id"
+  type  = "String"
+  value = module.network.vpc_id
+  tags  = local.ssm_tags
+}
+
+resource "aws_ssm_parameter" "private_subnet_ids" {
+  name  = "${local.ssm_prefix}/network/private-subnet-ids"
+  type  = "StringList"
+  value = join(",", module.network.private_subnet_ids)
+  tags  = local.ssm_tags
+}
+
+resource "aws_ssm_parameter" "public_subnet_ids" {
+  name  = "${local.ssm_prefix}/network/public-subnet-ids"
+  type  = "StringList"
+  value = join(",", module.network.public_subnet_ids)
+  tags  = local.ssm_tags
+}
+
+resource "aws_ssm_parameter" "lambda_sg_id" {
+  name  = "${local.ssm_prefix}/network/lambda-sg-id"
+  type  = "String"
+  value = module.network.lambda_sg_id
+  tags  = local.ssm_tags
+}
+
+resource "aws_ssm_parameter" "rds_endpoint" {
+  name  = "${local.ssm_prefix}/rds/endpoint"
+  type  = "String"
+  value = module.database.effective_endpoint
+  tags  = local.ssm_tags
+}
+
+resource "aws_ssm_parameter" "rds_port" {
+  name  = "${local.ssm_prefix}/rds/port"
+  type  = "String"
+  value = tostring(module.database.db_port)
+  tags  = local.ssm_tags
+}
+
+resource "aws_ssm_parameter" "rds_secret_arn" {
+  name  = "${local.ssm_prefix}/rds/secret-arn"
+  type  = "String"
+  value = nonsensitive(module.database.secret_arn)
+  tags  = local.ssm_tags
 }

--- a/fluxion-backend/terraform/envs/dev/outputs.tf
+++ b/fluxion-backend/terraform/envs/dev/outputs.tf
@@ -1,0 +1,20 @@
+output "vpc_id" {
+  description = "ID of the VPC."
+  value       = module.network.vpc_id
+}
+
+output "rds_endpoint" {
+  description = "Effective RDS endpoint (proxy when enabled, direct address otherwise)."
+  value       = module.database.effective_endpoint
+}
+
+output "rds_secret_arn" {
+  description = "ARN of the Secrets Manager secret holding DB credentials."
+  value       = module.database.secret_arn
+  sensitive   = true
+}
+
+output "ssm_prefix" {
+  description = "SSM Parameter Store path prefix for this environment."
+  value       = local.ssm_prefix
+}

--- a/fluxion-backend/terraform/envs/dev/terraform.tfvars.example
+++ b/fluxion-backend/terraform/envs/dev/terraform.tfvars.example
@@ -1,1 +1,4 @@
-aws_region = "ap-southeast-1"
+aws_region           = "ap-southeast-1"
+env                  = "dev"
+resource_name_prefix = "fluxion-dev"
+enable_rds_proxy     = false

--- a/fluxion-backend/terraform/envs/dev/variables.tf
+++ b/fluxion-backend/terraform/envs/dev/variables.tf
@@ -3,3 +3,19 @@ variable "aws_region" {
   default     = "ap-southeast-1"
   description = "AWS region."
 }
+
+variable "env" {
+  type    = string
+  default = "dev"
+}
+
+variable "resource_name_prefix" {
+  type    = string
+  default = "fluxion-dev"
+}
+
+variable "enable_rds_proxy" {
+  type        = bool
+  default     = false
+  description = "Feature flag — dev=false to save cost (~$22/mo extra). Staging/prod=true."
+}

--- a/fluxion-backend/terraform/modules/database/README.md
+++ b/fluxion-backend/terraform/modules/database/README.md
@@ -1,0 +1,90 @@
+# database module
+
+Provisions a **PostgreSQL 16 RDS instance** with Secrets Manager credentials and an optional **RDS Proxy** (feature-flagged, disabled by default).
+
+## Architecture
+
+```
+                     (enable_rds_proxy = true)
+Lambda ──▶ sg-rds-proxy ──▶ RDS Proxy ──▶ sg-rds ──▶ RDS instance
+                                 │
+                                 └──▶ Secrets Manager (proxy auth)
+
+                     (enable_rds_proxy = false)
+Lambda ──▶ sg-rds ──▶ RDS instance (direct)
+                    Secrets Manager (app reads at startup)
+```
+
+## Feature flag: `enable_rds_proxy`
+
+| Value | Resources created | Monthly cost delta |
+|-------|------------------|--------------------|
+| `false` (default) | RDS + Secret only | Free-tier eligible |
+| `true` | + IAM role/policy + Proxy + target group + target | ~+$22/mo (t3.micro) |
+
+Enable for production workloads where connection pooling and IAM auth are needed. Keep `false` for dev to stay within free tier.
+
+## Inputs
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `resource_name_prefix` | `string` | — | Resource name prefix, e.g. `fluxion-dev` |
+| `env` | `string` | — | Environment: `dev`, `staging`, `prod` |
+| `private_subnet_ids` | `list(string)` | — | Private subnet IDs from network module |
+| `rds_sg_id` | `string` | — | RDS security group ID from network module |
+| `rds_proxy_sg_id` | `string` | — | RDS Proxy security group ID from network module |
+| `db_name` | `string` | `fluxion` | Initial database name |
+| `db_username` | `string` | `fluxion_admin` | Master username |
+| `instance_class` | `string` | `db.t3.micro` | RDS instance class |
+| `allocated_storage` | `number` | `20` | Storage in GB |
+| `engine_version` | `string` | `16.3` | PostgreSQL version (pinned) |
+| `enable_rds_proxy` | `bool` | `false` | Enable RDS Proxy in front of DB |
+| `backup_retention_period` | `number` | `7` | Backup retention days (0 = disabled) |
+
+## Outputs
+
+| Name | Sensitive | Description |
+|------|-----------|-------------|
+| `db_instance_id` | no | RDS instance identifier |
+| `db_endpoint` | no | Direct writer endpoint (`host:port`) |
+| `db_port` | no | Port (5432) |
+| `proxy_endpoint` | no | Proxy endpoint; `null` when disabled |
+| `effective_endpoint` | no | Recommended endpoint for consumers |
+| `secret_arn` | **yes** | Secrets Manager secret ARN |
+| `secret_name` | no | Secrets Manager secret name |
+
+Always wire `effective_endpoint` to application config — it automatically resolves to the proxy when enabled and falls back to the direct RDS address otherwise.
+
+## Consumer pattern (Lambda reads secret)
+
+Phase 3 stores `secret_arn` in SSM Parameter Store. A Lambda retrieves it at cold-start:
+
+```python
+import boto3, json, os
+
+ssm = boto3.client("ssm")
+sm  = boto3.client("secretsmanager")
+
+def get_db_credentials():
+    secret_arn = ssm.get_parameter(
+        Name=os.environ["DB_SECRET_ARN_SSM_PATH"],
+        WithDecryption=True,
+    )["Parameter"]["Value"]
+    secret = sm.get_secret_value(SecretId=secret_arn)
+    return json.loads(secret["SecretString"])
+    # returns {"username": "fluxion_admin", "password": "..."}
+```
+
+The Lambda execution role needs:
+- `ssm:GetParameter` on the SSM path
+- `secretsmanager:GetSecretValue` on the secret ARN
+
+## Security notes
+
+- RDS is **not publicly accessible** (`publicly_accessible = false`)
+- Dev instance is **not encrypted at rest** (`storage_encrypted` not set); enable for staging/prod
+- Password auto-generated (32 chars, URL-safe special chars) and stored only in Secrets Manager
+- `secret_arn` output is marked `sensitive = true` — will not appear in plain `terraform output`
+- IAM role for Proxy uses least-privilege: `secretsmanager:GetSecretValue` on the specific secret ARN only
+- `deletion_protection = false` and `skip_final_snapshot = true` are intentional for dev; override for prod
+- `recovery_window_in_days = 0` on the secret enables fast destroy in dev; use default (30) for prod

--- a/fluxion-backend/terraform/modules/database/README.md
+++ b/fluxion-backend/terraform/modules/database/README.md
@@ -37,7 +37,7 @@ Enable for production workloads where connection pooling and IAM auth are needed
 | `db_username` | `string` | `fluxion_admin` | Master username |
 | `instance_class` | `string` | `db.t3.micro` | RDS instance class |
 | `allocated_storage` | `number` | `20` | Storage in GB |
-| `engine_version` | `string` | `16.3` | PostgreSQL version (pinned) |
+| `engine_version` | `string` | `16.8` | PostgreSQL version (pinned) |
 | `enable_rds_proxy` | `bool` | `false` | Enable RDS Proxy in front of DB |
 | `backup_retention_period` | `number` | `7` | Backup retention days (0 = disabled) |
 

--- a/fluxion-backend/terraform/modules/database/main.tf
+++ b/fluxion-backend/terraform/modules/database/main.tf
@@ -1,0 +1,13 @@
+# Database module entry point.
+# Resources are split by category per module-structure.md §7 (>300 LOC → split):
+#   secret.tf  — random_password, Secrets Manager secret + version
+#   rds.tf     — DB subnet group, RDS instance
+#   proxy.tf   — IAM role/policy, RDS Proxy + target group + target (conditional)
+
+locals {
+  common_tags = {
+    Project   = "fluxion"
+    Env       = var.env
+    ManagedBy = "terraform"
+  }
+}

--- a/fluxion-backend/terraform/modules/database/outputs.tf
+++ b/fluxion-backend/terraform/modules/database/outputs.tf
@@ -1,0 +1,35 @@
+output "db_instance_id" {
+  description = "Identifier of the RDS DB instance."
+  value       = aws_db_instance.main.id
+}
+
+output "db_endpoint" {
+  description = "Direct writer endpoint of the RDS instance (host:port)."
+  value       = aws_db_instance.main.endpoint
+}
+
+output "db_port" {
+  description = "Port the RDS instance listens on (5432 for PostgreSQL)."
+  value       = aws_db_instance.main.port
+}
+
+output "proxy_endpoint" {
+  description = "Endpoint of the RDS Proxy. null when enable_rds_proxy=false."
+  value       = one(aws_db_proxy.main[*].endpoint)
+}
+
+output "effective_endpoint" {
+  description = "Recommended endpoint for consumers: proxy endpoint when enabled, otherwise direct RDS address."
+  value       = var.enable_rds_proxy ? aws_db_proxy.main[0].endpoint : aws_db_instance.main.address
+}
+
+output "secret_arn" {
+  description = "ARN of the Secrets Manager secret holding DB credentials (username + password JSON)."
+  value       = aws_secretsmanager_secret.main.arn
+  sensitive   = true
+}
+
+output "secret_name" {
+  description = "Name of the Secrets Manager secret (use for IAM resource scope or SDK lookup)."
+  value       = aws_secretsmanager_secret.main.name
+}

--- a/fluxion-backend/terraform/modules/database/proxy.tf
+++ b/fluxion-backend/terraform/modules/database/proxy.tf
@@ -1,0 +1,83 @@
+# RDS Proxy: IAM role + policy, proxy, target group, target.
+# All resources gated by var.enable_rds_proxy (count = 0 when disabled).
+# Proxy adds ~$22/mo for t3.micro (2 vCPU × $0.015/vCPU-hr × 730hr); disabled by default.
+
+resource "aws_iam_role" "proxy" {
+  count = var.enable_rds_proxy ? 1 : 0
+
+  name        = "${var.resource_name_prefix}-rds-proxy-role"
+  description = "Allows RDS Proxy to retrieve DB credentials from Secrets Manager."
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { Service = "rds.amazonaws.com" }
+        Action    = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = local.common_tags
+}
+
+resource "aws_iam_role_policy" "proxy" {
+  count = var.enable_rds_proxy ? 1 : 0
+
+  name = "${var.resource_name_prefix}-rds-proxy-policy"
+  role = aws_iam_role.proxy[0].id
+
+  # Least-privilege: only GetSecretValue on the specific DB credentials secret.
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "secretsmanager:GetSecretValue"
+        Resource = aws_secretsmanager_secret.main.arn
+      }
+    ]
+  })
+}
+
+resource "aws_db_proxy" "main" {
+  count = var.enable_rds_proxy ? 1 : 0
+
+  name                   = "${var.resource_name_prefix}-db-proxy"
+  debug_logging          = false
+  engine_family          = "POSTGRESQL"
+  idle_client_timeout    = 1800
+  require_tls            = true
+  role_arn               = aws_iam_role.proxy[0].arn
+  vpc_subnet_ids         = var.private_subnet_ids
+  vpc_security_group_ids = [var.rds_proxy_sg_id]
+
+  auth {
+    auth_scheme = "SECRETS"
+    iam_auth    = "DISABLED"
+    secret_arn  = aws_secretsmanager_secret.main.arn
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${var.resource_name_prefix}-db-proxy"
+  })
+}
+
+resource "aws_db_proxy_default_target_group" "main" {
+  count = var.enable_rds_proxy ? 1 : 0
+
+  db_proxy_name = aws_db_proxy.main[0].name
+
+  connection_pool_config {
+    max_connections_percent = 100
+  }
+}
+
+resource "aws_db_proxy_target" "main" {
+  count = var.enable_rds_proxy ? 1 : 0
+
+  db_proxy_name          = aws_db_proxy.main[0].name
+  target_group_name      = aws_db_proxy_default_target_group.main[0].name
+  db_instance_identifier = aws_db_instance.main.identifier
+}

--- a/fluxion-backend/terraform/modules/database/rds.tf
+++ b/fluxion-backend/terraform/modules/database/rds.tf
@@ -1,0 +1,58 @@
+# RDS: subnet group + PostgreSQL 16 instance (single-AZ, dev-optimised settings).
+
+resource "aws_db_subnet_group" "main" {
+  name        = "${var.resource_name_prefix}-db-subnet-group"
+  subnet_ids  = var.private_subnet_ids
+  description = "Subnet group for ${var.resource_name_prefix} RDS instance (private subnets)."
+
+  tags = merge(local.common_tags, {
+    Name = "${var.resource_name_prefix}-db-subnet-group"
+  })
+}
+
+resource "aws_db_instance" "main" {
+  identifier = "${var.resource_name_prefix}-db"
+
+  # Engine
+  engine                     = "postgres"
+  engine_version             = var.engine_version
+  auto_minor_version_upgrade = false # Pin minor version; upgrade explicitly per release process.
+
+  # Sizing
+  instance_class    = var.instance_class
+  allocated_storage = var.allocated_storage
+  storage_type      = "gp2"
+
+  # Credentials — password pulled from random_password directly to avoid circular dep
+  # with the secret. The secret stores the same value for app/proxy consumption.
+  db_name  = var.db_name
+  username = var.db_username
+  password = random_password.main.result
+
+  # Networking
+  db_subnet_group_name   = aws_db_subnet_group.main.name
+  vpc_security_group_ids = [var.rds_sg_id]
+  publicly_accessible    = false
+  multi_az               = false
+
+  # Backup / maintenance
+  backup_retention_period = var.backup_retention_period
+  backup_window           = "17:00-18:00"         # UTC — off-peak for ap-southeast-1
+  maintenance_window      = "Sun:18:00-Sun:19:00" # UTC — immediately after backup window
+
+  # Dev-safe destroy settings
+  skip_final_snapshot = true
+  deletion_protection = false
+  apply_immediately   = true # Apply parameter changes without waiting for next window (dev).
+
+  # Allow out-of-band password rotation (e.g. Secrets Manager rotation Lambda)
+  # without Terraform attempting to revert the password on the next plan.
+  lifecycle {
+    ignore_changes = [password]
+  }
+
+  tags = merge(local.common_tags, {
+    Name          = "${var.resource_name_prefix}-db"
+    auto-shutdown = "dev"
+  })
+}

--- a/fluxion-backend/terraform/modules/database/secret.tf
+++ b/fluxion-backend/terraform/modules/database/secret.tf
@@ -1,0 +1,28 @@
+# Secrets Manager: random password generation + secret storage for RDS credentials.
+# The secret is consumed by the app at runtime and by RDS Proxy for connection auth.
+
+resource "random_password" "main" {
+  length  = 32
+  special = true
+  # Exclude chars that break PostgreSQL URL encoding or JSON: / @ " space \ '
+  override_special = "!#$%&*()-_=+[]{}<>:?"
+}
+
+resource "aws_secretsmanager_secret" "main" {
+  name        = "${var.resource_name_prefix}/db/credentials"
+  description = "RDS master credentials for ${var.resource_name_prefix} PostgreSQL instance."
+
+  # recovery_window=0 allows immediate deletion during `terraform destroy` in dev.
+  # staging/prod should use the default (30 days).
+  recovery_window_in_days = 0
+
+  tags = local.common_tags
+}
+
+resource "aws_secretsmanager_secret_version" "main" {
+  secret_id = aws_secretsmanager_secret.main.id
+  secret_string = jsonencode({
+    username = var.db_username
+    password = random_password.main.result
+  })
+}

--- a/fluxion-backend/terraform/modules/database/variables.tf
+++ b/fluxion-backend/terraform/modules/database/variables.tf
@@ -49,7 +49,7 @@ variable "allocated_storage" {
 
 variable "engine_version" {
   type        = string
-  default     = "16.3"
+  default     = "16.8"
   description = "PostgreSQL engine version. Pinned to avoid unexpected upgrade surprises."
 }
 

--- a/fluxion-backend/terraform/modules/database/variables.tf
+++ b/fluxion-backend/terraform/modules/database/variables.tf
@@ -1,0 +1,66 @@
+variable "resource_name_prefix" {
+  type        = string
+  description = "Prefix for all resource names, e.g. 'fluxion-dev'."
+}
+
+variable "env" {
+  type        = string
+  description = "Deployment environment: dev, staging, or prod."
+}
+
+variable "private_subnet_ids" {
+  type        = list(string)
+  description = "IDs of private subnets for the RDS subnet group (from network module)."
+}
+
+variable "rds_sg_id" {
+  type        = string
+  description = "Security group ID attached to the RDS instance (from network module)."
+}
+
+variable "rds_proxy_sg_id" {
+  type        = string
+  description = "Security group ID attached to the RDS Proxy (from network module)."
+}
+
+variable "db_name" {
+  type        = string
+  default     = "fluxion"
+  description = "Name of the initial database to create inside the RDS instance."
+}
+
+variable "db_username" {
+  type        = string
+  default     = "fluxion_admin"
+  description = "Master username for the RDS instance."
+}
+
+variable "instance_class" {
+  type        = string
+  default     = "db.t3.micro"
+  description = "RDS instance class. db.t3.micro is free-tier eligible for the first 12 months."
+}
+
+variable "allocated_storage" {
+  type        = number
+  default     = 20
+  description = "Allocated storage in GB. 20 GB is the free-tier maximum."
+}
+
+variable "engine_version" {
+  type        = string
+  default     = "16.3"
+  description = "PostgreSQL engine version. Pinned to avoid unexpected upgrade surprises."
+}
+
+variable "enable_rds_proxy" {
+  type        = bool
+  default     = false
+  description = "Feature flag: create an RDS Proxy in front of the DB instance. Adds ~$22/mo for t3.micro; disabled by default for dev cost savings."
+}
+
+variable "backup_retention_period" {
+  type        = number
+  default     = 7
+  description = "Number of days to retain automated backups (1–35). Set 0 to disable."
+}

--- a/fluxion-backend/terraform/modules/database/versions.tf
+++ b/fluxion-backend/terraform/modules/database/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.10"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.70"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+}

--- a/fluxion-backend/terraform/modules/network/README.md
+++ b/fluxion-backend/terraform/modules/network/README.md
@@ -1,0 +1,93 @@
+# modules/network
+
+Provisions the core network layer for a Fluxion environment:
+
+- **VPC** (`10.0.0.0/16` default) with DNS hostnames enabled
+- **2 public subnets** + **2 private subnets** across 2 AZs
+- **Internet Gateway** + public route table
+- **fck-nat** ([fck-nat.dev](https://fck-nat.dev)) — ARM t4g.nano ASG (size=1) with a static ENI + EIP; ~$3/mo vs $32/mo for Managed NAT Gateway
+- **Private route table** pointing to the NAT ENI
+- **3 Security Groups** forming the Lambda → RDS Proxy → RDS ingress chain
+
+## Inputs
+
+| Name | Type | Default | Description |
+|---|---|---|---|
+| `resource_name_prefix` | `string` | — | Prefix for all resource names (e.g. `fluxion-dev`) |
+| `env` | `string` | — | Deployment environment: `dev`, `staging`, `prod` |
+| `vpc_cidr` | `string` | `10.0.0.0/16` | VPC CIDR block |
+| `azs` | `list(string)` | `["ap-southeast-1a","ap-southeast-1b"]` | AZs (exactly 2, index-aligned with subnet CIDRs) |
+| `public_subnet_cidrs` | `list(string)` | `["10.0.0.0/24","10.0.1.0/24"]` | Public subnet CIDRs |
+| `private_subnet_cidrs` | `list(string)` | `["10.0.10.0/24","10.0.11.0/24"]` | Private subnet CIDRs |
+| `fck_nat_instance_type` | `string` | `t4g.nano` | EC2 instance type for NAT (ARM Graviton) |
+
+## Outputs
+
+| Name | Description |
+|---|---|
+| `vpc_id` | VPC ID |
+| `vpc_cidr_block` | VPC CIDR block |
+| `public_subnet_ids` | List of public subnet IDs |
+| `private_subnet_ids` | List of private subnet IDs |
+| `lambda_sg_id` | Security group ID for Lambda functions |
+| `rds_sg_id` | Security group ID for RDS instances |
+| `rds_proxy_sg_id` | Security group ID for RDS Proxy |
+| `nat_eip` | Public IP of the NAT EIP (for debugging / allowlisting) |
+
+## SSM Naming Convention
+
+The `envs/dev` environment exports network outputs to SSM Parameter Store under:
+
+```
+/fluxion/{env}/network/vpc-id
+/fluxion/{env}/network/vpc-cidr
+/fluxion/{env}/network/public-subnet-ids     # comma-separated list
+/fluxion/{env}/network/private-subnet-ids    # comma-separated list
+/fluxion/{env}/network/lambda-sg-id
+/fluxion/{env}/network/rds-sg-id
+/fluxion/{env}/network/rds-proxy-sg-id
+/fluxion/{env}/network/nat-eip
+```
+
+Other sub-repos consume these via `data "aws_ssm_parameter"` — never via shared Terraform state.
+
+## Security Group Chain
+
+```
+Lambda (sg-lambda)
+  │ egress: 0.0.0.0/0 all
+  │
+  ├──► RDS Proxy (sg-rds-proxy)
+  │      ingress: tcp 5432 from sg-lambda
+  │
+  └──► RDS (sg-rds)
+         ingress: tcp 5432 from sg-lambda       ← proxy-off path
+         ingress: tcp 5432 from sg-rds-proxy    ← proxy-on path
+```
+
+## Example Usage
+
+```hcl
+module "network" {
+  source = "../../modules/network"
+
+  resource_name_prefix = "fluxion-dev"
+  env                  = "dev"
+
+  # All other vars use defaults (ap-southeast-1, 10.0.0.0/16, t4g.nano)
+}
+
+# Wire outputs to SSM for cross-stack consumption
+resource "aws_ssm_parameter" "vpc_id" {
+  name  = "/fluxion/dev/network/vpc-id"
+  type  = "String"
+  value = module.network.vpc_id
+}
+```
+
+## Notes
+
+- fck-nat runs in **public AZ-a only** (single-AZ by design for dev cost savings). Private subnets in AZ-b route through the same NAT ENI — acceptable SPOF for dev.
+- The NAT ENI (`aws_network_interface.nat`) is **static** — it survives ASG instance recycling. The fck-nat boot script attaches it via `/etc/fck-nat.conf` → `fck-nat.service`.
+- SSM AMI path: `/aws/service/fck-nat/fck-nat-al2023-arm64-latest/amzn2023` — verify with `aws ssm get-parameter --name <path>` if `terraform plan` reports a data source error.
+- `terraform validate` requires a root module context — run it from `envs/dev/` in Phase 3, not here.

--- a/fluxion-backend/terraform/modules/network/main.tf
+++ b/fluxion-backend/terraform/modules/network/main.tf
@@ -1,0 +1,13 @@
+# Network module entry point.
+# Resources are split by category per module-structure.md §7 (>300 LOC → split):
+#   networking.tf   — VPC, IGW, subnets, route tables
+#   nat.tf          — fck-nat ENI, EIP, IAM, Launch Template, ASG
+#   security-groups.tf — Lambda / RDS Proxy / RDS SG chain
+
+locals {
+  common_tags = {
+    Project   = "fluxion"
+    Env       = var.env
+    ManagedBy = "terraform"
+  }
+}

--- a/fluxion-backend/terraform/modules/network/nat.tf
+++ b/fluxion-backend/terraform/modules/network/nat.tf
@@ -5,12 +5,24 @@
 # to a stable network_interface_id. On each boot, the ASG instance runs
 # fck-nat.service which reads /etc/fck-nat.conf and attaches the ENI.
 #
-# SSM AMI path to verify if data source errors appear in Phase 3:
-#   /aws/service/fck-nat/fck-nat-al2023-arm64-latest/amzn2023
+# fck-nat publishes AMIs directly (not via /aws/service/ SSM namespace which
+# is reserved for AWS-first-party). Lookup by publisher account + name pattern.
+# Publisher account: 568608671756 (fck-nat official)
+# Docs: https://fck-nat.dev/stable/deploying/#terraform
 
-# Resolve latest fck-nat AMI for Amazon Linux 2023 ARM64
-data "aws_ssm_parameter" "fck_nat_ami" {
-  name = "/aws/service/fck-nat/fck-nat-al2023-arm64-latest/amzn2023"
+data "aws_ami" "fck_nat" {
+  most_recent = true
+  owners      = ["568608671756"]
+
+  filter {
+    name   = "name"
+    values = ["fck-nat-al2023-*-arm64-ebs"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["arm64"]
+  }
 }
 
 # ---------------------------------------------------------------------------
@@ -94,7 +106,7 @@ resource "aws_iam_instance_profile" "fck_nat" {
 
 resource "aws_launch_template" "fck_nat" {
   name_prefix   = "${var.resource_name_prefix}-fck-nat-"
-  image_id      = data.aws_ssm_parameter.fck_nat_ami.value
+  image_id      = data.aws_ami.fck_nat.id
   instance_type = var.fck_nat_instance_type
 
   iam_instance_profile {

--- a/fluxion-backend/terraform/modules/network/nat.tf
+++ b/fluxion-backend/terraform/modules/network/nat.tf
@@ -1,0 +1,155 @@
+# fck-nat NAT instance: standalone ENI (source_dest_check=false), static EIP,
+# IAM role/profile, Launch Template, and ASG size=1 in public AZ-a.
+#
+# Design: ENI is static (module lifetime) so the private route table can point
+# to a stable network_interface_id. On each boot, the ASG instance runs
+# fck-nat.service which reads /etc/fck-nat.conf and attaches the ENI.
+#
+# SSM AMI path to verify if data source errors appear in Phase 3:
+#   /aws/service/fck-nat/fck-nat-al2023-arm64-latest/amzn2023
+
+# Resolve latest fck-nat AMI for Amazon Linux 2023 ARM64
+data "aws_ssm_parameter" "fck_nat_ami" {
+  name = "/aws/service/fck-nat/fck-nat-al2023-arm64-latest/amzn2023"
+}
+
+# ---------------------------------------------------------------------------
+# Standalone ENI — survives ASG instance recycling
+# ---------------------------------------------------------------------------
+
+resource "aws_network_interface" "nat" {
+  subnet_id         = aws_subnet.public[var.azs[0]].id
+  source_dest_check = false
+
+  tags = merge(local.common_tags, {
+    Name = "${var.resource_name_prefix}-nat-eni"
+  })
+}
+
+# EIP attached to ENI (not instance) — stable public IP across recycles
+resource "aws_eip" "nat" {
+  domain            = "vpc"
+  network_interface = aws_network_interface.nat.id
+
+  tags = merge(local.common_tags, {
+    Name = "${var.resource_name_prefix}-nat-eip"
+  })
+
+  depends_on = [aws_internet_gateway.main]
+}
+
+# ---------------------------------------------------------------------------
+# IAM — instance profile lets boot script call EC2 API to attach ENI
+# ---------------------------------------------------------------------------
+
+resource "aws_iam_role" "fck_nat" {
+  name = "${var.resource_name_prefix}-fck-nat-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "ec2.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+
+  tags = merge(local.common_tags, {
+    Name = "${var.resource_name_prefix}-fck-nat-role"
+  })
+}
+
+resource "aws_iam_role_policy" "fck_nat_eni_attach" {
+  name = "fck-nat-eni-attach"
+  role = aws_iam_role.fck_nat.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "ec2:AttachNetworkInterface",
+        "ec2:ModifyNetworkInterfaceAttribute",
+        "ec2:AssociateAddress",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DescribeInstances",
+      ]
+      Resource = "*"
+    }]
+  })
+}
+
+resource "aws_iam_instance_profile" "fck_nat" {
+  name = "${var.resource_name_prefix}-fck-nat-profile"
+  role = aws_iam_role.fck_nat.name
+
+  tags = merge(local.common_tags, {
+    Name = "${var.resource_name_prefix}-fck-nat-profile"
+  })
+}
+
+# ---------------------------------------------------------------------------
+# Launch Template + ASG
+# ---------------------------------------------------------------------------
+
+resource "aws_launch_template" "fck_nat" {
+  name_prefix   = "${var.resource_name_prefix}-fck-nat-"
+  image_id      = data.aws_ssm_parameter.fck_nat_ami.value
+  instance_type = var.fck_nat_instance_type
+
+  iam_instance_profile {
+    name = aws_iam_instance_profile.fck_nat.name
+  }
+
+  # fck-nat.service reads /etc/fck-nat.conf at boot and attaches the ENI
+  user_data = base64encode(<<-EOT
+    #!/bin/bash
+    echo "eni_id=${aws_network_interface.nat.id}" > /etc/fck-nat.conf
+    systemctl enable --now fck-nat.service
+  EOT
+  )
+
+  tag_specifications {
+    resource_type = "instance"
+    tags = merge(local.common_tags, {
+      Name = "${var.resource_name_prefix}-fck-nat"
+    })
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# ASG size=1 in public AZ-a — auto-heals on instance failure (single-AZ SPOF
+# is acceptable for dev; upgrade to multi-AZ for prod if needed)
+resource "aws_autoscaling_group" "fck_nat" {
+  name                = "${var.resource_name_prefix}-fck-nat-asg"
+  min_size            = 1
+  max_size            = 1
+  desired_capacity    = 1
+  vpc_zone_identifier = [aws_subnet.public[var.azs[0]].id]
+
+  launch_template {
+    id      = aws_launch_template.fck_nat.id
+    version = "$Latest"
+  }
+
+  tag {
+    key                 = "Project"
+    value               = "fluxion"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "Env"
+    value               = var.env
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "ManagedBy"
+    value               = "terraform"
+    propagate_at_launch = true
+  }
+}

--- a/fluxion-backend/terraform/modules/network/networking.tf
+++ b/fluxion-backend/terraform/modules/network/networking.tf
@@ -1,0 +1,113 @@
+# VPC, Internet Gateway, public/private subnets (2 AZ), and route tables.
+# fck-nat ENI is defined in nat.tf; private route table points to it.
+
+# ---------------------------------------------------------------------------
+# VPC
+# ---------------------------------------------------------------------------
+
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = merge(local.common_tags, {
+    Name = "${var.resource_name_prefix}-vpc"
+  })
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = merge(local.common_tags, {
+    Name = "${var.resource_name_prefix}-igw"
+  })
+}
+
+# ---------------------------------------------------------------------------
+# Subnets — for_each over AZ index keeps CIDR/AZ pairs aligned
+# ---------------------------------------------------------------------------
+
+resource "aws_subnet" "public" {
+  for_each = {
+    for i, az in var.azs : az => {
+      cidr = var.public_subnet_cidrs[i]
+      az   = az
+    }
+  }
+
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = each.value.cidr
+  availability_zone       = each.value.az
+  map_public_ip_on_launch = true
+
+  tags = merge(local.common_tags, {
+    Name = "${var.resource_name_prefix}-public-${each.key}"
+    Tier = "public"
+  })
+}
+
+resource "aws_subnet" "private" {
+  for_each = {
+    for i, az in var.azs : az => {
+      cidr = var.private_subnet_cidrs[i]
+      az   = az
+    }
+  }
+
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = each.value.cidr
+  availability_zone = each.value.az
+
+  tags = merge(local.common_tags, {
+    Name = "${var.resource_name_prefix}-private-${each.key}"
+    Tier = "private"
+  })
+}
+
+# ---------------------------------------------------------------------------
+# Public route table → IGW
+# ---------------------------------------------------------------------------
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${var.resource_name_prefix}-rt-public"
+  })
+}
+
+resource "aws_route_table_association" "public" {
+  for_each = aws_subnet.public
+
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.public.id
+}
+
+# ---------------------------------------------------------------------------
+# Private route table → NAT ENI (defined in nat.tf)
+# ---------------------------------------------------------------------------
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block           = "0.0.0.0/0"
+    network_interface_id = aws_network_interface.nat.id
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${var.resource_name_prefix}-rt-private"
+  })
+}
+
+resource "aws_route_table_association" "private" {
+  for_each = aws_subnet.private
+
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.private.id
+}

--- a/fluxion-backend/terraform/modules/network/outputs.tf
+++ b/fluxion-backend/terraform/modules/network/outputs.tf
@@ -1,0 +1,39 @@
+output "vpc_id" {
+  description = "ID of the VPC."
+  value       = aws_vpc.main.id
+}
+
+output "vpc_cidr_block" {
+  description = "CIDR block of the VPC."
+  value       = aws_vpc.main.cidr_block
+}
+
+output "public_subnet_ids" {
+  description = "IDs of the public subnets (one per AZ)."
+  value       = [for s in aws_subnet.public : s.id]
+}
+
+output "private_subnet_ids" {
+  description = "IDs of the private subnets (one per AZ)."
+  value       = [for s in aws_subnet.private : s.id]
+}
+
+output "lambda_sg_id" {
+  description = "Security group ID for Lambda functions."
+  value       = aws_security_group.lambda.id
+}
+
+output "rds_sg_id" {
+  description = "Security group ID for RDS instances."
+  value       = aws_security_group.rds.id
+}
+
+output "rds_proxy_sg_id" {
+  description = "Security group ID for RDS Proxy."
+  value       = aws_security_group.rds_proxy.id
+}
+
+output "nat_eip" {
+  description = "Public IP of the fck-nat EIP (useful for debug / allowlisting)."
+  value       = aws_eip.nat.public_ip
+}

--- a/fluxion-backend/terraform/modules/network/security-groups.tf
+++ b/fluxion-backend/terraform/modules/network/security-groups.tf
@@ -1,0 +1,71 @@
+# Security Groups for the Lambda → RDS Proxy → RDS ingress chain.
+#
+# Chain:
+#   sg-lambda    egress all → internet / VPC
+#   sg-rds-proxy ingress tcp/5432 from sg-lambda only
+#   sg-rds       ingress tcp/5432 from sg-lambda (proxy-off path)
+#                             AND from sg-rds-proxy (proxy-on path)
+#
+# No circular dependency — chain is linear, so inline ingress blocks are fine.
+
+resource "aws_security_group" "lambda" {
+  name        = "${var.resource_name_prefix}-sg-lambda"
+  description = "Lambda functions — unrestricted egress, no ingress needed."
+  vpc_id      = aws_vpc.main.id
+
+  egress {
+    description = "Allow all outbound traffic"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${var.resource_name_prefix}-sg-lambda"
+  })
+}
+
+resource "aws_security_group" "rds_proxy" {
+  name        = "${var.resource_name_prefix}-sg-rds-proxy"
+  description = "RDS Proxy — accept PostgreSQL from Lambda SG only."
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description     = "PostgreSQL from Lambda"
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [aws_security_group.lambda.id]
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${var.resource_name_prefix}-sg-rds-proxy"
+  })
+}
+
+resource "aws_security_group" "rds" {
+  name        = "${var.resource_name_prefix}-sg-rds"
+  description = "RDS — accept PostgreSQL from Lambda SG and RDS Proxy SG."
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description     = "PostgreSQL from Lambda (proxy-off path)"
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [aws_security_group.lambda.id]
+  }
+
+  ingress {
+    description     = "PostgreSQL from RDS Proxy"
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [aws_security_group.rds_proxy.id]
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${var.resource_name_prefix}-sg-rds"
+  })
+}

--- a/fluxion-backend/terraform/modules/network/security-groups.tf
+++ b/fluxion-backend/terraform/modules/network/security-groups.tf
@@ -10,7 +10,7 @@
 
 resource "aws_security_group" "lambda" {
   name        = "${var.resource_name_prefix}-sg-lambda"
-  description = "Lambda functions — unrestricted egress, no ingress needed."
+  description = "Lambda functions - unrestricted egress, no ingress needed."
   vpc_id      = aws_vpc.main.id
 
   egress {
@@ -28,7 +28,7 @@ resource "aws_security_group" "lambda" {
 
 resource "aws_security_group" "rds_proxy" {
   name        = "${var.resource_name_prefix}-sg-rds-proxy"
-  description = "RDS Proxy — accept PostgreSQL from Lambda SG only."
+  description = "RDS Proxy - accept PostgreSQL from Lambda SG only."
   vpc_id      = aws_vpc.main.id
 
   ingress {
@@ -46,7 +46,7 @@ resource "aws_security_group" "rds_proxy" {
 
 resource "aws_security_group" "rds" {
   name        = "${var.resource_name_prefix}-sg-rds"
-  description = "RDS — accept PostgreSQL from Lambda SG and RDS Proxy SG."
+  description = "RDS - accept PostgreSQL from Lambda SG and RDS Proxy SG."
   vpc_id      = aws_vpc.main.id
 
   ingress {

--- a/fluxion-backend/terraform/modules/network/variables.tf
+++ b/fluxion-backend/terraform/modules/network/variables.tf
@@ -1,0 +1,39 @@
+variable "resource_name_prefix" {
+  type        = string
+  description = "Prefix for all resource names, e.g. 'fluxion-dev'."
+}
+
+variable "env" {
+  type        = string
+  description = "Deployment environment: dev, staging, or prod."
+}
+
+variable "vpc_cidr" {
+  type        = string
+  default     = "10.0.0.0/16"
+  description = "CIDR block for the VPC."
+}
+
+variable "azs" {
+  type        = list(string)
+  default     = ["ap-southeast-1a", "ap-southeast-1b"]
+  description = "Availability zones to deploy subnets into (exactly 2 required)."
+}
+
+variable "public_subnet_cidrs" {
+  type        = list(string)
+  default     = ["10.0.0.0/24", "10.0.1.0/24"]
+  description = "CIDR blocks for public subnets (one per AZ, index-aligned with azs)."
+}
+
+variable "private_subnet_cidrs" {
+  type        = list(string)
+  default     = ["10.0.10.0/24", "10.0.11.0/24"]
+  description = "CIDR blocks for private subnets (one per AZ, index-aligned with azs)."
+}
+
+variable "fck_nat_instance_type" {
+  type        = string
+  default     = "t4g.nano"
+  description = "EC2 instance type for the fck-nat NAT instance (ARM Graviton recommended)."
+}

--- a/fluxion-backend/terraform/modules/network/versions.tf
+++ b/fluxion-backend/terraform/modules/network/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.10"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.70"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `modules/network/` — VPC 10.0.0.0/16, 4 subnets (2 AZ), fck-nat t4g.nano NAT instance with static ENI + EIP, 3 SG ingress chain (Lambda → RDS Proxy → RDS)
- `modules/database/` — RDS PG 16.8 t3.micro + Secrets Manager + conditional RDS Proxy (feature flag `enable_rds_proxy`, default `false` for dev)
- `envs/dev/` — wired both modules, exports 7 SSM parameters under `/fluxion/dev/` for cross-service consumption
- Docs: `docs/module-structure.md §5.4` documents network module; root README notes Terraform module layout

Closes #30

## Validation
- [x] `terraform fmt -check -recursive` pass
- [x] `terraform validate` pass
- [x] `terraform plan` → 34 to add / 0 change / 0 destroy
- [x] `terraform apply` — all 34 resources provisioned
- [x] All 7 SSM parameters verified via `aws ssm get-parameter`
- [x] `terraform destroy` clean (34 destroyed)

## Cost
~$4-5/mo dev with `enable_rds_proxy=false` (RDS free tier 12mo + fck-nat ~$3 + Secret $0.40). Staging/prod flip the flag when NFR2.4 connection pooling matters.

## Fixes applied during validation
- fck-nat AMI lookup: `/aws/service/` namespace reserved for AWS-first-party → switched to `data "aws_ami"` with fck-nat publisher account `568608671756`
- SG descriptions: ASCII-only (AWS EC2 rejects em-dash)
- PG `16.3` → `16.8` (earlier deprecated in ap-southeast-1)

## SSM contract
| Path | Type | Source |
|---|---|---|
| `/fluxion/dev/network/vpc-id` | String | `module.network.vpc_id` |
| `/fluxion/dev/network/private-subnet-ids` | StringList | `module.network.private_subnet_ids` |
| `/fluxion/dev/network/public-subnet-ids` | StringList | `module.network.public_subnet_ids` |
| `/fluxion/dev/network/lambda-sg-id` | String | `module.network.lambda_sg_id` |
| `/fluxion/dev/rds/endpoint` | String | `module.database.effective_endpoint` |
| `/fluxion/dev/rds/port` | String | `module.database.db_port` |
| `/fluxion/dev/rds/secret-arn` | String | `module.database.secret_arn` |

OEM processor consumes via `data "aws_ssm_parameter"` — see `envs/dev/README.md`.