### PR TITLE
[#32]: add autoscaling:* to gha-deploy policy

### DIFF
--- a/fluxion-backend/terraform/bootstrap/oidc.tf
+++ b/fluxion-backend/terraform/bootstrap/oidc.tf
@@ -103,6 +103,7 @@ data "aws_iam_policy_document" "gha_deploy_inline" {
     actions = [
       "cognito-idp:*",
       "ec2:*",
+      "autoscaling:*",
       "rds:*",
       "lambda:*",
       "appsync:*",


### PR DESCRIPTION
Surfaced on main Deploy after #69 merge: `CreateAutoScalingGroup` AccessDenied (fck-nat ASG). Policy already re-applied to AWS; this PR syncs code.

## Test plan
- [ ] PR CI green
- [ ] Main Deploy tf-backend apply clean