### PR TITLE
[#74]: grant ecr:DeleteLifecyclePolicy to gha-deploy role

### DIFF
--- a/fluxion-backend/terraform/bootstrap/oidc.tf
+++ b/fluxion-backend/terraform/bootstrap/oidc.tf
@@ -89,6 +89,7 @@ data "aws_iam_policy_document" "gha_deploy_inline" {
       "ecr:DeleteRepository",
       "ecr:PutLifecyclePolicy",
       "ecr:GetLifecyclePolicy",
+      "ecr:DeleteLifecyclePolicy",
       "ecr:TagResource",
       "ecr:UntagResource",
       "ecr:ListTagsForResource",


### PR DESCRIPTION
## Summary
- Master Deploy (post-#76) failed destroying leftover `fluxion-dev-smoketest` ECR — role lacked `ecr:DeleteLifecyclePolicy`
- Adds the missing action to bootstrap inline policy
- Bootstrap already applied locally against AWS — this commit syncs code to deployed state

## Test plan
- [x] `terraform apply` on bootstrap (locally, profile=fluxion-dev) → 0 add / 1 change / 0 destroy
- [ ] Re-run failed master Deploy after merge → develop → master promotion