### PR TITLE
[#74]: promote ecr:DeleteLifecyclePolicy fix to master

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -6,7 +6,7 @@ on:
       - "fluxion-backend/**"
       - ".github/workflows/ci-backend.yml"
   push:
-    branches: [main]
+    branches: [master]
     paths:
       - "fluxion-backend/**"
       - ".github/workflows/ci-backend.yml"

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -6,7 +6,7 @@ on:
       - "fluxion-frontend/**"
       - ".github/workflows/ci-frontend.yml"
   push:
-    branches: [main]
+    branches: [master]
     paths:
       - "fluxion-frontend/**"
       - ".github/workflows/ci-frontend.yml"

--- a/.github/workflows/ci-oem-processor.yml
+++ b/.github/workflows/ci-oem-processor.yml
@@ -6,7 +6,7 @@ on:
       - "fluxion-oem-processor/**"
       - ".github/workflows/ci-oem-processor.yml"
   push:
-    branches: [main]
+    branches: [master]
     paths:
       - "fluxion-oem-processor/**"
       - ".github/workflows/ci-oem-processor.yml"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,9 +2,9 @@ name: Deploy
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
-    branches: [main]
+    branches: [master]
 
 concurrency:
   # Serialize main-branch applies; PR plan runs keyed by PR so they don't block each other.

--- a/docs/code-standards.md
+++ b/docs/code-standards.md
@@ -492,7 +492,7 @@ These commands **will be** CI gates. Until the pre-commit / CI ticket lands, run
 | Terraform | validate | `terraform validate` | Fail on error |
 | Terraform | tflint | `tflint --recursive` | Fail on error |
 | SQL | sqlfluff | `sqlfluff lint migrations/` | Fail on error |
-| Commits | commitlint | `commitlint --from origin/main` | Fail on non-conforming |
+| Commits | commitlint | `commitlint --from origin/master` | Fail on non-conforming |
 
 ---
 

--- a/docs/development-roadmap.md
+++ b/docs/development-roadmap.md
@@ -92,7 +92,7 @@ Cognito User Pool with email-based auth (custom:role attribute), ECR module auto
 
 1. **Terraform Bootstrap** (`terraform/bootstrap/`)
    - GitHub OIDC provider + `fluxion-backend-gha-deploy` IAM role
-   - Trust policy scoped to `repo:congsinhv/fluxion:ref:refs/heads/main` (auto-apply) + PR refs (plan-only)
+   - Trust policy scoped to `repo:congsinhv/fluxion:ref:refs/heads/master` (auto-apply, prod) + PR refs (plan-only)
    - Inline policy: S3, DynamoDB, RDS, ECR, Cognito, Secrets Manager, SSM access
 
 2. **Cognito Module** (`terraform/modules/auth/`)

--- a/docs/project-changelog.md
+++ b/docs/project-changelog.md
@@ -27,7 +27,7 @@
 
 **`terraform/bootstrap/` — OIDC & Deploy Role (applied once, bootstrap-only)**
 - GitHub OIDC provider (OIDC issuer, audience, thumbprint)
-- `fluxion-backend-gha-deploy` IAM role (trust policy scoped to `repo:congsinhv/fluxion:ref:refs/heads/main` + PR refs)
+- `fluxion-backend-gha-deploy` IAM role (trust policy scoped to `repo:congsinhv/fluxion:ref:refs/heads/master` + PR refs)
 - Inline policy: Terraform state (S3 + DynamoDB), RDS, ECR, Cognito, Secrets Manager, SSM Parameter Store
 - Environment: `dev` only (stage/prod in future ticket #33)
 

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -277,14 +277,24 @@ Idempotency key sourced from:
 
 ### 8.1 GitHub Actions Workflow (`deploy.yml`)
 
-Two-phase deployment strategy: plan-only on PR; auto-apply on merge to main.
+Two-phase deployment strategy: plan-only on PR; auto-apply on merge to `master` (prod).
 
-**On `push: main`** (auto-apply, no manual approval):
+**Git flow:**
+```
+feature/<N>-<slug> ──(PR)──▶ develop ──(manual dev deploy)──┐
+                                                            ▼
+                               (PR at phase close) develop ──▶ master  ──(CI/CD auto-apply, prod)
+```
+
+- `develop` — integration branch, **no CI/CD**; operator runs `terraform apply` locally for dev-env verification.
+- `master` — prod branch; push triggers `deploy.yml` which applies Terraform + pushes ECR images.
+
+**On `push: master`** (auto-apply, no manual approval):
 ```
 lint (flake8) ─→ test (pytest) ─→ terraform apply ─→ docker push matrix
 ```
 
-**On `pull_request`** (plan-only, gates merge):
+**On `pull_request` (to master)** (plan-only, gates merge):
 ```
 lint (flake8) ─→ test (pytest) ─→ terraform plan (artifact) ─→ [blocked: no apply/push]
 ```
@@ -309,8 +319,9 @@ lint (flake8) ─→ test (pytest) ─→ terraform plan (artifact) ─→ [bloc
 - Issuer: `https://token.actions.githubusercontent.com`
 - Audience: `sts.amazonaws.com`
 - Trust policy scoped to:
-  - `repo:congsinhv/fluxion:ref:refs/heads/main` — auto-apply on push:main
+  - `repo:congsinhv/fluxion:ref:refs/heads/master` — auto-apply on push:master (prod CI/CD)
   - `repo:congsinhv/fluxion:pull_request` — plan-only for PR validation
+  - `develop` branch is dev-env integration only — no CI/CD trust needed (manual deploy)
 
 **IAM Role: `fluxion-backend-gha-deploy`**
 - Permissions: Terraform state (S3, DynamoDB lock), RDS, ECR, Cognito, Secrets Manager, SSM Parameter Store

--- a/fluxion-backend/terraform/bootstrap/oidc.tf
+++ b/fluxion-backend/terraform/bootstrap/oidc.tf
@@ -31,13 +31,14 @@ data "aws_iam_policy_document" "gha_deploy_trust" {
       values   = ["sts.amazonaws.com"]
     }
 
-    # Allow: pushes to main, tag pushes, and pull_request events.
+    # Allow: pushes to master (prod), tag pushes, and pull_request events.
+    # `develop` is dev-env integration branch — no CI runs there, so no trust needed.
     # PR hardening (plan-only) deferred to follow-up ticket.
     condition {
       test     = "StringLike"
       variable = "token.actions.githubusercontent.com:sub"
       values = [
-        "repo:${var.github_repo}:ref:refs/heads/main",
+        "repo:${var.github_repo}:ref:refs/heads/master",
         "repo:${var.github_repo}:ref:refs/tags/*",
         "repo:${var.github_repo}:pull_request",
       ]

--- a/fluxion-backend/terraform/bootstrap/oidc.tf
+++ b/fluxion-backend/terraform/bootstrap/oidc.tf
@@ -89,6 +89,7 @@ data "aws_iam_policy_document" "gha_deploy_inline" {
       "ecr:DeleteRepository",
       "ecr:PutLifecyclePolicy",
       "ecr:GetLifecyclePolicy",
+      "ecr:DeleteLifecyclePolicy",
       "ecr:TagResource",
       "ecr:UntagResource",
       "ecr:ListTagsForResource",


### PR DESCRIPTION
## Summary
- Promotes #77 (bootstrap IAM fix) from develop → master
- Unblocks failing master Deploy run that errored destroying leftover `fluxion-dev-smoketest` ECR

## Test plan
- [x] Bootstrap applied locally
- [x] PR #77 green on develop
- [ ] Master Deploy green after merge