### PR TITLE
[#34]: deploy.yml — split tf-backend into ECR bootstrap + full apply

### DIFF
--- a/.github/actions/terraform-apply/action.yml
+++ b/.github/actions/terraform-apply/action.yml
@@ -17,6 +17,14 @@ inputs:
     description: S3 bucket for remote backend (passed to terraform init -backend-config).
     required: false
     default: "fluxion-backend-tfstate"
+  targets:
+    description: |
+      Optional space-separated targets for partial apply (e.g. "module.ecr aws_ssm_parameter.ecr_repo_urls").
+      Each entry becomes a `-target=<value>` arg on plan + apply. Used for bootstrap
+      stages where downstream jobs (docker push) need a subset of resources before
+      the full apply can run.
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -31,10 +39,20 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       run: terraform init -input=false -backend-config="bucket=${{ inputs.backend-bucket }}"
 
+    - name: build target args
+      id: targets
+      shell: bash
+      run: |
+        args=""
+        for t in ${{ inputs.targets }}; do
+          args="$args -target=$t"
+        done
+        echo "args=$args" >> "$GITHUB_OUTPUT"
+
     - name: terraform plan
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      run: terraform plan -input=false -out=tfplan -no-color
+      run: terraform plan -input=false -out=tfplan -no-color ${{ steps.targets.outputs.args }}
 
     - name: terraform apply
       if: inputs.apply == 'true'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -135,10 +135,38 @@ jobs:
             echo "::endgroup::"
           done
 
-  tf-backend:
-    name: terraform backend (dev)
+  tf-backend-ecr-bootstrap:
+    # Bootstrap stage: create ECR repos before docker-push runs.
+    # The full tf-backend apply needs Lambda image_uri to resolve to an existing
+    # image, which docker-push only produces after ECR repos exist. This stage
+    # breaks the chicken-and-egg by applying the ECR module first.
+    name: terraform backend ECR bootstrap (dev)
     needs: [detect-changes, lint-test-backend]
     if: needs.detect-changes.outputs.backend == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/aws-oidc-login
+        with:
+          role-arn: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          region: ${{ env.AWS_REGION }}
+      - uses: ./.github/actions/terraform-apply
+        with:
+          working-directory: fluxion-backend/terraform/envs/dev
+          apply: ${{ github.event_name == 'push' }}
+          terraform-version: ${{ env.TF_VERSION }}
+          targets: "module.ecr aws_ssm_parameter.ecr_repo_urls"
+
+  tf-backend:
+    name: terraform backend (dev)
+    # Run AFTER docker-push so Lambda image_uri references an image that exists.
+    needs: [detect-changes, lint-test-backend, docker-push-backend]
+    if: |
+      always() &&
+      needs.detect-changes.outputs.backend == 'true' &&
+      needs.lint-test-backend.result == 'success' &&
+      (needs.docker-push-backend.result == 'success' || needs.docker-push-backend.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -173,7 +201,9 @@ jobs:
 
   docker-push-backend:
     name: docker push backend matrix
-    needs: [detect-changes, tf-backend]
+    # Depends on the ECR bootstrap (repos must exist) — NOT on full tf-backend,
+    # which itself depends on this job for image_uri to resolve.
+    needs: [detect-changes, tf-backend-ecr-bootstrap]
     if: >-
       github.event_name == 'push' &&
       needs.detect-changes.outputs.backend == 'true' &&


### PR DESCRIPTION
## Why

First deploy of #34 (PR #81) failed because the workflow runs `tf-backend` BEFORE `docker-push-backend`:

```
ERROR: creating Lambda Function (fluxion-dev-user-resolver):
  InvalidParameterValueException: Source image
  439155107355.dkr.ecr.ap-southeast-1.amazonaws.com/fluxion-dev-user_resolver:latest
  does not exist. Provide a valid source image.
```

`tf-backend` tries to create Lambda functions whose `image_uri = "${ecr_url}:latest"`, but `:latest` doesn't exist on first deploy — `docker-push-backend` only runs after `tf-backend` succeeds. Chicken-and-egg.

## Fix

Split `tf-backend` into 3 stages:

```
lint
  → tf-backend-ecr-bootstrap   (terraform apply -target=module.ecr ...)
  → docker-push-backend         (push images to now-existing repos)
  → tf-backend                  (full apply; Lambdas resolve to real images)
```

`docker-push-backend.needs` flips from `tf-backend` → `tf-backend-ecr-bootstrap`.
`tf-backend.needs` adds `docker-push-backend`.

`terraform-apply` composite action gains a `targets` input that converts a space-separated string into `-target=...` args, so the bootstrap stage can do partial apply without forking the action.

## Why future-proof

Any new Lambda module added to `fluxion-backend/modules/` will go through the same 3-stage flow on its first deploy. No more bootstrap surgery needed.

## Scope

OEM workflow keeps the original ordering — only matters on greenfield, and OEM is already deployed. Can mirror this pattern for OEM later if a new OEM module gets added.

## Recovery plan after merge

1. Merge this PR into `develop`
2. Promote `develop` → `master` via PR (triggers Deploy workflow with the fix)
3. Workflow runs end-to-end: ECR bootstrap (idempotent — repos already exist from failed run) → docker-push → full tf-backend → Lambdas created
4. Run `provision-dev-admin.sh` + `smoke-appsync.sh` against deployed dev