### PR TITLE
[#34]: Dockerfiles — self-contained, no workspace-base dependency

### DIFF
--- a/fluxion-backend/modules/_template/Dockerfile
+++ b/fluxion-backend/modules/_template/Dockerfile
@@ -1,10 +1,18 @@
-# Inherits from the workspace-level base image built from Dockerfile.resolver.
-# Build the base first: docker build -f Dockerfile.resolver -t fluxion-backend/resolver-base:latest .
-FROM fluxion-backend/resolver-base:latest
+# Template Lambda container image — copy this when scaffolding a new resolver.
+# Self-contained: no dependency on a workspace-built base image.
+# Build context (from CI/.github/workflows/deploy.yml): fluxion-backend/
 
-# Copy src/ contents flat into LAMBDA_TASK_ROOT so imports resolve as
-# `from config import X` rather than `from src.config import X`.
-# This mirrors pytest pythonpath = ["src"] at test time.
-COPY src/ ${LAMBDA_TASK_ROOT}/
+FROM public.ecr.aws/lambda/python:3.12
+
+# Runtime deps mirror modules/_template/pyproject.toml.
+# When scaffolding a real Lambda, update this list to match the new module's deps.
+RUN pip install --no-cache-dir \
+    "psycopg[binary]>=3.1,<4" \
+    "pydantic>=2.6" \
+    "aws-lambda-powertools>=2.30"
+
+# Source — flat-COPY into LAMBDA_TASK_ROOT so imports resolve as
+# `from config import X` (mirrors pytest pythonpath = ["src"]).
+COPY modules/_template/src/ ${LAMBDA_TASK_ROOT}/
 
 CMD ["handler.lambda_handler"]

--- a/fluxion-backend/modules/device_resolver/Dockerfile
+++ b/fluxion-backend/modules/device_resolver/Dockerfile
@@ -1,5 +1,15 @@
-FROM fluxion-backend/resolver-base:latest
+# device_resolver Lambda container image.
+# Self-contained: no dependency on a workspace-built base image.
+# Build context (from CI/.github/workflows/deploy.yml): fluxion-backend/
 
-COPY src/ ${LAMBDA_TASK_ROOT}/
+FROM public.ecr.aws/lambda/python:3.12
+
+# Runtime deps mirror modules/device_resolver/pyproject.toml.
+RUN pip install --no-cache-dir \
+    "psycopg[binary]>=3.1,<4" \
+    "pydantic>=2.6" \
+    "aws-lambda-powertools>=2.30"
+
+COPY modules/device_resolver/src/ ${LAMBDA_TASK_ROOT}/
 
 CMD ["handler.lambda_handler"]

--- a/fluxion-backend/modules/platform_resolver/Dockerfile
+++ b/fluxion-backend/modules/platform_resolver/Dockerfile
@@ -1,5 +1,17 @@
-FROM fluxion-backend/resolver-base:latest
+# platform_resolver Lambda container image.
+# Self-contained: no dependency on a workspace-built base image.
+# Build context (from CI/.github/workflows/deploy.yml): fluxion-backend/
 
-COPY src/ ${LAMBDA_TASK_ROOT}/
+FROM public.ecr.aws/lambda/python:3.12
+
+# Runtime deps mirror modules/platform_resolver/pyproject.toml.
+# Cached layer — only invalidated when this list changes.
+RUN pip install --no-cache-dir \
+    "psycopg[binary]>=3.1,<4" \
+    "pydantic>=2.6" \
+    "aws-lambda-powertools>=2.30"
+
+# Source — invalidates on any code change but deps stay cached above.
+COPY modules/platform_resolver/src/ ${LAMBDA_TASK_ROOT}/
 
 CMD ["handler.lambda_handler"]

--- a/fluxion-backend/modules/user_resolver/Dockerfile
+++ b/fluxion-backend/modules/user_resolver/Dockerfile
@@ -1,11 +1,17 @@
-FROM fluxion-backend/resolver-base:latest
+# user_resolver Lambda container image.
+# Self-contained: no dependency on a workspace-built base image.
+# Build context (from CI/.github/workflows/deploy.yml): fluxion-backend/
 
-# user_resolver requires boto3 for Cognito admin operations.
-# The resolver-base image only installs psycopg/pydantic/powertools;
-# boto3 is available in the AWS Lambda runtime but must be added here
-# so that the container image works correctly in integration tests.
-RUN uv pip install --system --no-cache "boto3>=1.34"
+FROM public.ecr.aws/lambda/python:3.12
 
-COPY src/ ${LAMBDA_TASK_ROOT}/
+# Runtime deps mirror modules/user_resolver/pyproject.toml.
+# boto3 is required for Cognito admin operations (admin_create_user, etc.).
+RUN pip install --no-cache-dir \
+    "psycopg[binary]>=3.1,<4" \
+    "pydantic>=2.6" \
+    "aws-lambda-powertools>=2.30" \
+    "boto3>=1.34"
+
+COPY modules/user_resolver/src/ ${LAMBDA_TASK_ROOT}/
 
 CMD ["handler.lambda_handler"]


### PR DESCRIPTION
## Why

Deploy run #24934022708 succeeded the ECR bootstrap step (PR #82 fix worked) but failed at docker-build-push:

\`\`\`
ERROR: failed to build: failed to solve: fluxion-backend/resolver-base:latest:
failed to resolve source metadata for docker.io/fluxion-backend/resolver-base:latest:
pull access denied, repository does not exist
\`\`\`

Module Dockerfiles all start with \`FROM fluxion-backend/resolver-base:latest\` — a local-only image built via \`docker build -f Dockerfile.resolver\`. Local dev workflow assumes you've pre-built that base. CI was never set up to build it, so \`docker-build-push-ecr\` couldn't resolve the parent layer.

## Fix

Each module's Dockerfile becomes self-contained:

\`\`\`dockerfile
FROM public.ecr.aws/lambda/python:3.12

RUN pip install --no-cache-dir \\
    "psycopg[binary]>=3.1,<4" \\
    "pydantic>=2.6" \\
    "aws-lambda-powertools>=2.30"

COPY modules/<name>/src/ \${LAMBDA_TASK_ROOT}/
CMD ["handler.lambda_handler"]
\`\`\`

\`user_resolver\` adds \`boto3>=1.34\` for Cognito admin ops. Source paths now use \`modules/<name>/src/\` since CI builds with context \`fluxion-backend/\`.

## Files changed

- \`modules/_template/Dockerfile\`
- \`modules/device_resolver/Dockerfile\`
- \`modules/platform_resolver/Dockerfile\`
- \`modules/user_resolver/Dockerfile\` (+ boto3)

\`Dockerfile.resolver\` at workspace root is preserved for local dev — its docstring still explains the manual base-build flow for laptop work.

## Trade-off

Dep list now duplicates pyproject.toml's \`[project.dependencies]\` (3-4 packages per module). Acceptable: Dockerfile is the deploy spec, pyproject is the dev/test spec. GHA layer cache (\`cache-from: type=gha\`) keeps the dep layer cached across runs.

## Recovery plan

1. Merge this PR → develop
2. Promote develop → master
3. Deploy workflow runs end-to-end:
   - tf-backend-ecr-bootstrap (no-op; repos exist)
   - docker-push-backend (3 images build successfully)
   - tf-backend full apply (Lambdas resolve to real images)
4. Run \`provision-dev-admin.sh\` + \`smoke-appsync.sh\`