### PR TITLE
[#34]: docker action — disable provenance/sbom for Lambda compat

### DIFF
--- a/.github/actions/docker-build-push-ecr/action.yml
+++ b/.github/actions/docker-build-push-ecr/action.yml
@@ -36,3 +36,8 @@ runs:
           ${{ steps.ecr.outputs.registry }}/${{ inputs.repository }}:latest
         cache-from: type=gha
         cache-to: type=gha,mode=max
+        # AWS Lambda only accepts Docker image manifest v2 schema 2; it rejects
+        # OCI image indexes that buildx adds via provenance/SBOM attestations.
+        # Disabling these keeps the manifest format Lambda-compatible.
+        provenance: false
+        sbom: false


### PR DESCRIPTION
## Why

Last deploy (24934656410) cleared all earlier hurdles (ECR bootstrap ✓, docker push ✓ for all 3 modules) but failed at tf-backend full apply:

\`\`\`
InvalidParameterValueException: The image manifest, config or layer media type
for the source image ...:latest is not supported.
\`\`\`

\`docker/build-push-action@v6\` defaults to including provenance + SBOM attestations, which produces an OCI image **index** (multi-manifest). AWS Lambda only accepts Docker manifest v2 schema 2 (single platform) — it rejects OCI indexes.

## Fix

One file change: add \`provenance: false\` + \`sbom: false\` to \`docker/build-push-action@v6\` inputs in \`.github/actions/docker-build-push-ecr/action.yml\`.

## After this lands

1. Merge to develop
2. Promote develop → master
3. Deploy workflow runs end-to-end:
   - lint ✓
   - tf-backend-ecr-bootstrap ✓ (no-op)
   - docker-push (rebuilds all 3 with single-platform manifest)
   - tf-backend full apply ✓ (Lambdas accept the manifests now)
4. Run \`provision-dev-admin.sh\` + \`smoke-appsync.sh\`