### PR TITLE
[#34]: AppSync uses Lambda function_arn, not invoke_arn

### DIFF
--- a/fluxion-backend/terraform/envs/dev/main.tf
+++ b/fluxion-backend/terraform/envs/dev/main.tf
@@ -107,9 +107,9 @@ module "api" {
   schema_path          = "${path.module}/../../../schema.graphql"
   cognito_user_pool_id = module.auth.user_pool_id
   lambda_resolver_arns = {
-    device   = module.resolver_device.invoke_arn
-    platform = module.resolver_platform.invoke_arn
-    user     = module.resolver_user.invoke_arn
+    device   = module.resolver_device.function_arn
+    platform = module.resolver_platform.function_arn
+    user     = module.resolver_user.function_arn
   }
   log_retention_days  = 14
   log_field_log_level = "ERROR"

--- a/fluxion-backend/terraform/modules/lambda_function/README.md
+++ b/fluxion-backend/terraform/modules/lambda_function/README.md
@@ -26,9 +26,9 @@ module "api" {
   source = "../../modules/api"
   # ...
   lambda_resolver_arns = {
-    device   = module.resolver_device.invoke_arn
-    platform = module.resolver_platform.invoke_arn
-    user     = module.resolver_user.invoke_arn
+    device   = module.resolver_device.function_arn
+    platform = module.resolver_platform.function_arn
+    user     = module.resolver_user.function_arn
   }
 }
 ```
@@ -80,8 +80,8 @@ module "resolver_user" {
 
 | Name | Description |
 |------|-------------|
-| `function_arn` | ARN of the Lambda function |
-| `invoke_arn` | Invoke ARN for AppSync Lambda data source |
+| `function_arn` | Plain Lambda ARN. **Use this for AppSync** Lambda data sources. |
+| `invoke_arn` | API Gateway-formatted invoke URL. Use ONLY for API Gateway integrations, NOT AppSync. |
 | `role_arn` | ARN of the Lambda execution IAM role |
 | `function_name` | Canonical function name as registered in AWS |
 

--- a/fluxion-backend/terraform/modules/lambda_function/outputs.tf
+++ b/fluxion-backend/terraform/modules/lambda_function/outputs.tf
@@ -1,11 +1,11 @@
 output "function_arn" {
   value       = aws_lambda_function.this.arn
-  description = "ARN of the Lambda function."
+  description = "Plain Lambda ARN. Use this for AppSync Lambda data sources."
 }
 
 output "invoke_arn" {
   value       = aws_lambda_function.this.invoke_arn
-  description = "Invoke ARN used by AppSync Lambda data source."
+  description = "API Gateway-formatted invoke URL (apigateway:.../path/...). Use ONLY for API Gateway integrations, NOT for AppSync."
 }
 
 output "role_arn" {


### PR DESCRIPTION
## Why

Last deploy (24951414995) cleared docker push (PR #90 manifest fix worked) but tf-backend full apply failed:

\`\`\`
Error: \"lambda_config.0.function_arn\"
(arn:aws:apigateway:ap-southeast-1:lambda:path/.../function:fluxion-dev-platform-resolver/invocations)
is an invalid ARN: invalid account ID value
\`\`\`

\`aws_lambda_function\` has two ARN-like outputs:
- \`.arn\` → \`arn:aws:lambda:region:account:function:name\` (plain ARN)
- \`.invoke_arn\` → \`arn:aws:apigateway:region:lambda:path/2015-03-31/functions/.../invocations\` (API Gateway integration URL)

**AppSync Lambda data sources require \`.arn\`**, not \`.invoke_arn\`. \`envs/dev/main.tf\` was passing \`.invoke_arn\` for all 3 resolvers.

## Fix

3 lines in \`envs/dev/main.tf\`:

\`\`\`hcl
lambda_resolver_arns = {
  device   = module.resolver_device.function_arn   # was: invoke_arn
  platform = module.resolver_platform.function_arn # was: invoke_arn
  user     = module.resolver_user.function_arn     # was: invoke_arn
}
\`\`\`

Also corrected the misleading \"used by AppSync\" description on the lambda_function module's \`invoke_arn\` output + README — they had it backwards.

## Verified

- \`terraform validate\` ✓
- Lambda functions themselves are already created in AWS (from the earlier failed run); next apply will only create AppSync DataSources + resolvers, skipping the Lambdas.

## After merge

1. Promote develop → master
2. Deploy runs:
   - lint ✓
   - tf-backend-ecr-bootstrap ✓ (no-op)
   - docker-push-backend ✓ (idempotent — :latest already current)
   - tf-backend full apply ✓ (~10 remaining resources: AppSync DataSources + resolvers)
3. Run \`provision-dev-admin.sh\` + \`smoke-appsync.sh\`