### PR TITLE
[#35]: action_resolver + upload_resolver Lambdas

### DIFF
--- a/fluxion-backend/migrations/versions/64066cf559b8_grant_dev_admin_action_upload.py
+++ b/fluxion-backend/migrations/versions/64066cf559b8_grant_dev_admin_action_upload.py
@@ -1,0 +1,81 @@
+"""Grant action/upload permissions to dev admin for dev1 tenant.
+
+Revision ID: 64066cf559b8
+Revises: cc44f3b5a815
+Create Date: 2026-04-26
+
+Grants the 3 new action/upload permission codes to ``dev-admin@fluxion.local``
+for the ``dev1`` tenant. The dev admin user row already exists (seeded in
+b9c3d1e2f4a5); this migration only inserts ``users_permissions`` rows.
+
+All inserts use ON CONFLICT DO NOTHING — safe to re-run.
+Depends on: cc44f3b5a815 (action/upload permissions catalog).
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "64066cf559b8"
+down_revision = "cc44f3b5a815"
+branch_labels = None
+depends_on = None
+
+_DEV_ADMIN_EMAIL = "dev-admin@fluxion.local"
+_DEV1_SCHEMA = "dev1"
+
+_PERMISSION_CODES = [
+    "action:execute",
+    "actionlog:read",
+    "upload:write",
+]
+
+
+def upgrade() -> None:
+    """Insert 3 permission grants for dev admin in dev1 tenant."""
+    conn = op.get_bind()
+
+    # Insert permission grants via sub-selects so we don't hard-code BIGINT IDs.
+    # User row already exists from b9c3d1e2f4a5 — no user INSERT needed here.
+    for code in _PERMISSION_CODES:
+        conn.execute(
+            sa.text(
+                """
+                INSERT INTO accesscontrol.users_permissions (user_id, permission_id, tenant_id)
+                SELECT u.id, p.id, t.id
+                FROM   accesscontrol.users       u,
+                       accesscontrol.permissions p,
+                       accesscontrol.tenants     t
+                WHERE  u.email       = :email
+                  AND  p.code        = :code
+                  AND  t.schema_name = :schema_name
+                ON CONFLICT (user_id, permission_id, tenant_id) DO NOTHING
+                """
+            ).bindparams(
+                email=_DEV_ADMIN_EMAIL,
+                code=code,
+                schema_name=_DEV1_SCHEMA,
+            )
+        )
+
+
+def downgrade() -> None:
+    """Remove the 3 action/upload permission grants from dev admin in dev1."""
+    conn = op.get_bind()
+
+    conn.execute(
+        sa.text(
+            """
+            DELETE FROM accesscontrol.users_permissions
+            WHERE user_id = (
+                SELECT id FROM accesscontrol.users WHERE email = :email
+            )
+            AND permission_id IN (
+                SELECT id FROM accesscontrol.permissions
+                WHERE code = ANY(:codes)
+            )
+            """
+        ).bindparams(email=_DEV_ADMIN_EMAIL, codes=_PERMISSION_CODES)
+    )

--- a/fluxion-backend/migrations/versions/cc44f3b5a815_seed_action_upload_permissions.py
+++ b/fluxion-backend/migrations/versions/cc44f3b5a815_seed_action_upload_permissions.py
@@ -1,0 +1,56 @@
+"""Seed action/upload permission catalog — 3 new resolver permission codes.
+
+Revision ID: cc44f3b5a815
+Revises: b9c3d1e2f4a5
+Create Date: 2026-04-26
+
+Inserts the 3 permission codes consumed by action_resolver and upload_resolver
+into ``accesscontrol.permissions``. Idempotent via ``ON CONFLICT (code) DO NOTHING``:
+safe to re-run, and safe if a manual insert already exists.
+
+Permission codes (GH-35 — action_resolver + upload_resolver):
+  action:execute  — assignAction / assignBulkAction (Command Pipeline write entry)
+  actionlog:read  — getActionLog / listActionLogs / generateActionLogErrorReport
+  upload:write    — uploadDevices bulk intake
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "cc44f3b5a815"
+down_revision = "b9c3d1e2f4a5"
+branch_labels = None
+depends_on = None
+
+_PERMISSIONS: list[tuple[str, str]] = [
+    ("action:execute", "assignAction / assignBulkAction — Command Pipeline write entry"),
+    ("actionlog:read", "getActionLog / listActionLogs / generateActionLogErrorReport"),
+    ("upload:write", "uploadDevices bulk device intake"),
+]
+
+
+def upgrade() -> None:
+    """Insert 3 permission codes; skip silently if already present."""
+    for code, description in _PERMISSIONS:
+        op.execute(
+            sa.text(
+                """
+                INSERT INTO accesscontrol.permissions (code, description)
+                VALUES (:code, :description)
+                ON CONFLICT (code) DO NOTHING
+                """
+            ).bindparams(code=code, description=description)
+        )
+
+
+def downgrade() -> None:
+    """Remove the 3 seeded permission codes (and their grants via CASCADE)."""
+    codes = [code for code, _ in _PERMISSIONS]
+    op.execute(
+        sa.text("DELETE FROM accesscontrol.permissions WHERE code = ANY(:codes)").bindparams(
+            codes=codes
+        )
+    )

--- a/fluxion-backend/modules/action_resolver/Dockerfile
+++ b/fluxion-backend/modules/action_resolver/Dockerfile
@@ -1,0 +1,19 @@
+# action_resolver Lambda container image.
+# Self-contained: no dependency on a workspace-built base image.
+# Build context (from CI/.github/workflows/deploy.yml): fluxion-backend/
+
+FROM public.ecr.aws/lambda/python:3.12
+
+# Runtime deps mirror modules/action_resolver/pyproject.toml.
+# boto3 is required for SQS SendMessage (action_trigger queue).
+RUN pip install --no-cache-dir \
+    "psycopg[binary]>=3.1,<4" \
+    "pydantic>=2.6" \
+    "aws-lambda-powertools>=2.30" \
+    "boto3>=1.34"
+
+# Source — flat-COPY into LAMBDA_TASK_ROOT so imports resolve as
+# `from config import X` (mirrors pytest pythonpath = ["src"]).
+COPY modules/action_resolver/src/ ${LAMBDA_TASK_ROOT}/
+
+CMD ["handler.lambda_handler"]

--- a/fluxion-backend/modules/action_resolver/pyproject.toml
+++ b/fluxion-backend/modules/action_resolver/pyproject.toml
@@ -1,0 +1,42 @@
+[project]
+name = "action-resolver"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+    "psycopg[binary]>=3.1,<4",
+    "pydantic>=2.6",
+    "aws-lambda-powertools>=2.30",
+    "boto3>=1.34",
+]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths = ["tests"]
+addopts = "--cov=src --cov-report=term-missing --cov-fail-under=80"
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "N", "W", "UP"]
+ignore = ["E501", "N815", "N806"]  # N815: camelCase Pydantic fields; N806: MockDB test vars
+
+[tool.mypy]
+strict = true
+python_version = "3.12"
+explicit_package_bases = true
+mypy_path = "src"
+# handler.py uses decorator-transformed callables whose post-decoration signature
+# mypy cannot always reconstruct (same pattern as user_resolver). Exclude from strict.
+exclude = ["src/handler\\.py"]
+
+[[tool.mypy.overrides]]
+# Local Lambda modules have no py.typed — ignore missing stubs for intra-module imports.
+module = ["auth", "config", "db", "exceptions", "schema_types", "sqs", "permissions"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+# boto3 / botocore ship no py.typed markers or bundled stubs.
+module = ["boto3", "botocore", "botocore.exceptions"]
+ignore_missing_imports = true

--- a/fluxion-backend/modules/action_resolver/src/auth.py
+++ b/fluxion-backend/modules/action_resolver/src/auth.py
@@ -1,0 +1,203 @@
+"""Auth helpers: context extraction + permission decorator.
+
+Two public symbols:
+  - ``build_context_from(event)`` — parses Cognito claims into a ``Context``.
+  - ``permission_required(permission)`` — decorator that enforces a permission code.
+  - ``validate_input(model, key)`` — decorator that validates args against a Pydantic model.
+
+Design-patterns.md §11.2: tenant_schema is resolved from the validated
+Cognito ``custom:tenant_id`` claim via accesscontrol.tenants lookup.
+``cognito_sub`` comes from ``event["identity"]["claims"]["sub"]`` which
+AppSync already verified — no re-verification needed.
+"""
+
+from __future__ import annotations
+
+import functools
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, TypeVar
+
+from pydantic import BaseModel
+
+from config import logger
+from db import Database
+from exceptions import AuthenticationError, ForbiddenError, InvalidInputError
+
+F = TypeVar("F", bound=Callable[..., Any])
+M = TypeVar("M", bound=BaseModel)
+
+
+@dataclass(frozen=True, slots=True)
+class Context:
+    """Resolved caller context, populated once per Lambda invocation.
+
+    Attributes:
+        cognito_sub: Cognito user subject UUID (from JWT claim ``sub``).
+        user_id: ``accesscontrol.users.id`` for this subject.
+        tenant_id: ``accesscontrol.tenants.id`` (BIGINT) from Cognito claim.
+        tenant_schema: Validated bare schema name (e.g. ``"dev1"``).
+    """
+
+    cognito_sub: str
+    user_id: int
+    tenant_id: int
+    tenant_schema: str
+
+
+def build_context_from(event: dict[str, Any]) -> Context:
+    """Extract and resolve caller identity from an AppSync resolver event.
+
+    Flow (per design-patterns.md §11.2):
+    1. Read ``cognito_sub`` from ``event["identity"]["claims"]["sub"]``.
+    2. Read ``tenant_id`` (BIGINT) from ``event["identity"]["claims"]["custom:tenant_id"]``.
+    3. Look up ``accesscontrol.users`` to get ``user_id``.
+    4. Look up ``accesscontrol.tenants`` to get validated ``schema_name``.
+
+    Args:
+        event: Raw AppSync Lambda resolver event.
+
+    Returns:
+        Populated ``Context`` for this invocation.
+
+    Raises:
+        AuthenticationError: Claims missing or identity block absent.
+        InvalidInputError: ``custom:tenant_id`` claim is not a valid integer.
+    """
+    try:
+        claims: dict[str, Any] = event["identity"]["claims"]
+        cognito_sub: str = claims["sub"]
+        raw_tenant_id: str = claims["custom:tenant_id"]
+    except (KeyError, TypeError) as exc:
+        raise AuthenticationError("missing identity claims") from exc
+
+    try:
+        tenant_id = int(raw_tenant_id)
+    except (ValueError, TypeError) as exc:
+        raise InvalidInputError(f"custom:tenant_id is not an integer: {raw_tenant_id!r}") from exc
+
+    with Database() as db:
+        tenant_schema = db.get_schema_name(tenant_id)
+        user_id = _resolve_user_id(db, cognito_sub)
+
+    return Context(
+        cognito_sub=cognito_sub,
+        user_id=user_id,
+        tenant_id=tenant_id,
+        tenant_schema=tenant_schema,
+    )
+
+
+def permission_required(permission: str) -> Callable[[F], F]:
+    """Decorator: resolve caller context and enforce a permission code.
+
+    Wraps a field handler ``(args, ctx, correlation_id) -> Any``.
+    Injects the resolved ``Context`` as ``ctx`` — the wrapped function
+    does NOT need to call ``build_context_from`` itself.
+
+    Args:
+        permission: Permission code to enforce (e.g. ``"action:execute"``).
+
+    Returns:
+        Decorator that injects ``ctx`` and raises ``ForbiddenError`` on miss.
+
+    Raises:
+        ForbiddenError: User does not hold the permission for the tenant.
+    """
+
+    def decorator(fn: F) -> F:
+        @functools.wraps(fn)
+        def wrapper(
+            args: dict[str, Any],
+            event: dict[str, Any],
+            correlation_id: str,
+        ) -> Any:
+            ctx = build_context_from(event)
+            with Database() as db:
+                if not db.has_permission(ctx.cognito_sub, ctx.tenant_id, permission):
+                    logger.warning(
+                        "auth.permission_denied",
+                        extra={
+                            "permission": permission,
+                            "cognito_sub": ctx.cognito_sub,
+                            "tenant_id": ctx.tenant_id,
+                            "correlation_id": correlation_id,
+                        },
+                    )
+                    raise ForbiddenError(f"missing permission: {permission}")
+            return fn(args, ctx, correlation_id)
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator
+
+
+def validate_input(model: type[M], key: str | None = None) -> Callable[[F], F]:  # noqa: UP047
+    """Decorator: validate an input dict against a Pydantic model.
+
+    The validated instance is appended as the last positional arg to the wrapped fn.
+    Wrapped signature: ``(args, ctx, correlation_id, inp)``.
+
+    Args:
+        model: Pydantic model class to validate against.
+        key: If set, validate ``args[key]`` (default empty dict if missing) instead
+            of ``args``. Use ``key="input"`` for AppSync mutation handlers.
+
+    Raises:
+        InvalidInputError: Validation failed.
+    """
+
+    def decorator(fn: F) -> F:
+        @functools.wraps(fn)
+        def wrapper(
+            args: dict[str, Any],
+            ctx: Context,
+            correlation_id: str,
+        ) -> Any:
+            raw: Any = args if key is None else args.get(key, {})
+            try:
+                inp = model.model_validate(raw)
+            except Exception as exc:
+                raise InvalidInputError(str(exc)) from exc
+            return fn(args, ctx, correlation_id, inp)
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator
+
+
+# ------------------------------------------------------------------
+# Internal helpers
+# ------------------------------------------------------------------
+
+
+def _resolve_user_id(db: Database, cognito_sub: str) -> int:
+    """Fetch accesscontrol.users.id for a cognito_sub.
+
+    Args:
+        db: Open Database instance (inside context manager).
+        cognito_sub: Cognito subject claim.
+
+    Returns:
+        Integer ``accesscontrol.users.id``.
+
+    Raises:
+        AuthenticationError: No user row found for this cognito_sub.
+    """
+    from exceptions import DatabaseError  # local import avoids circular at module level
+
+    conn = db._require_conn()  # noqa: SLF001 — auth.py is a sibling module, not external
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT id FROM accesscontrol.users WHERE cognito_sub = %s",
+                (cognito_sub,),
+            )
+            row = cur.fetchone()
+    except Exception as exc:
+        raise DatabaseError("user lookup failed") from exc
+
+    if not row:
+        raise AuthenticationError(f"no user for cognito_sub={cognito_sub!r}")
+
+    return int(row["id"])

--- a/fluxion-backend/modules/action_resolver/src/config.py
+++ b/fluxion-backend/modules/action_resolver/src/config.py
@@ -1,0 +1,40 @@
+"""Environment variables and logger — single source of truth for action_resolver Lambda.
+
+All handlers and services import `logger` (and any env var constants) from here.
+Never call `os.environ` directly in other modules (see design-patterns.md §4).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+LOG_LEVEL: str = os.environ.get("LOG_LEVEL", "INFO")
+POWERTOOLS_SERVICE_NAME: str = os.environ.get("POWERTOOLS_SERVICE_NAME", "action_resolver")
+
+logging.basicConfig(
+    level=LOG_LEVEL,
+    format='{"level":"%(levelname)s","service":"%(name)s","message":"%(message)s"}',
+)
+logger: logging.Logger = logging.getLogger(POWERTOOLS_SERVICE_NAME)
+
+# ---------------------------------------------------------------------------
+# Required environment variables
+# ---------------------------------------------------------------------------
+
+# DATABASE_URI must be set for any Lambda that uses db.py.
+# Safe default so unit tests can import config without a real DB present.
+# Real Lambda must always inject DATABASE_URI via env.
+DATABASE_URI: str = os.environ.get("DATABASE_URI", "")
+
+# ACTION_TRIGGER_QUEUE_URL is the SQS queue URL for the action trigger consumer.
+# Must be injected at Lambda cold start; empty string is safe for unit tests.
+ACTION_TRIGGER_QUEUE_URL: str = os.environ.get("ACTION_TRIGGER_QUEUE_URL", "")
+
+# UPLOADS_BUCKET is the S3 bucket name for action-log error CSV reports.
+# Lifecycle rule on action-log-errors/* expires objects after 30 days (P0).
+UPLOADS_BUCKET: str = os.environ.get("UPLOADS_BUCKET", "")

--- a/fluxion-backend/modules/action_resolver/src/csv_render.py
+++ b/fluxion-backend/modules/action_resolver/src/csv_render.py
@@ -1,0 +1,48 @@
+"""CSV renderer for ActionLog error reports.
+
+Produces UTF-8 + BOM encoded bytes suitable for S3 upload and Excel/LibreOffice
+opening without charset prompts.
+
+Columns (fixed order):
+  device_id, error_code, error_message, finished_at
+
+0-row case: returns header-only CSV (with BOM) — callers must NOT raise on empty.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from typing import Any
+
+# Fixed column order matches schema.graphql comment + GH-35 architectural decision #8.
+_HEADERS: list[str] = ["device_id", "error_code", "error_message", "finished_at"]
+
+
+def render_failed_devices_csv(rows: list[dict[str, Any]]) -> bytes:
+    """Render a list of failed-device dicts to UTF-8 + BOM CSV bytes.
+
+    Each dict in ``rows`` must contain keys: ``device_id``, ``error_code``,
+    ``error_message``, ``finished_at``.  Missing keys are written as empty
+    strings (defensive).
+
+    Args:
+        rows: List of failed-device row dicts from db.get_failed_devices_for_batch.
+              May be empty — produces header-only CSV with BOM.
+
+    Returns:
+        UTF-8 + BOM encoded bytes (starts with ``\\xef\\xbb\\xbf``).
+    """
+    buf = io.StringIO()
+    writer = csv.writer(buf, lineterminator="\n")
+    writer.writerow(_HEADERS)
+    for row in rows:
+        writer.writerow(
+            [
+                str(row.get("device_id", "")),
+                str(row.get("error_code", "")),
+                str(row.get("error_message", "")),
+                str(row.get("finished_at", "")),
+            ]
+        )
+    return buf.getvalue().encode("utf-8-sig")

--- a/fluxion-backend/modules/action_resolver/src/db.py
+++ b/fluxion-backend/modules/action_resolver/src/db.py
@@ -1,0 +1,669 @@
+"""psycopg3 repository for action_resolver.
+
+Tenant-isolated: every SQL query uses psycopg.sql.Identifier for schema names.
+Never use f-string interpolation for schema names (SQL injection defense).
+
+Tables used (per-tenant schema):
+  devices           — id UUID, state_id SMALLINT, assigned_action_id UUID
+  actions           — id UUID, from_state_id SMALLINT
+  batch_actions     — id UUID, batch_id UUID, action_id UUID, created_by TEXT,
+                      total_devices INT, status VARCHAR
+  batch_device_actions — id UUID, batch_id UUID, device_id UUID, status VARCHAR
+  action_executions — id UUID, device_id UUID, action_id UUID,
+                      command_uuid UUID, status VARCHAR
+  message_templates — id UUID, content TEXT, is_active BOOLEAN
+
+Race-safe device assignment:
+  UPDATE devices SET assigned_action_id=... WHERE id=ANY(...) AND assigned_action_id IS NULL
+  RETURNING id
+Only returned IDs are considered successfully locked; missing IDs go to failed[].
+"""
+
+from __future__ import annotations
+
+import base64
+import re
+import uuid
+from datetime import UTC, datetime
+from typing import Any, NamedTuple
+
+import psycopg
+import psycopg.rows
+import psycopg.sql
+
+from config import DATABASE_URI, logger
+from exceptions import DatabaseError, InvalidInputError, TenantNotFoundError
+
+# Matches accesscontrol.tenants.ck_tenants_schema_name_format.
+# Bare names only: dev1, acme, fpt (no prefix). See design-patterns.md §11.2.
+_SCHEMA_NAME_RE: re.Pattern[str] = re.compile(r"^[a-z][a-z0-9_]{0,39}$")
+
+
+def _validate_schema(schema_name: str) -> str:
+    """Raise DatabaseError if schema_name fails the safety regex."""
+    if not _SCHEMA_NAME_RE.fullmatch(schema_name):
+        raise DatabaseError(f"invalid schema_name: {schema_name!r}")
+    return schema_name
+
+
+# ---------------------------------------------------------------------------
+# Cursor helpers for list_action_logs pagination
+# ---------------------------------------------------------------------------
+
+_CURSOR_SEP = "|"
+
+
+def _encode_action_log_cursor(created_at: Any, id_: Any) -> str:
+    """Encode a (created_at, id) tuple as a URL-safe base64 cursor token.
+
+    Args:
+        created_at: datetime object or ISO string for the last row.
+        id_:        UUID or string for the last row's PK.
+
+    Returns:
+        URL-safe base64 string suitable for use as ``nextToken``.
+    """
+    ts = created_at.isoformat() if hasattr(created_at, "isoformat") else str(created_at)
+    raw = f"{ts}{_CURSOR_SEP}{id_}"
+    return base64.urlsafe_b64encode(raw.encode()).decode()
+
+
+def _decode_action_log_cursor(token: str) -> tuple[datetime, uuid.UUID]:
+    """Decode a nextToken cursor back to (created_at, id) tuple.
+
+    Args:
+        token: URL-safe base64 cursor string.
+
+    Returns:
+        (created_at datetime with UTC tzinfo, id UUID)
+
+    Raises:
+        InvalidInputError: Token is malformed, missing separator, or contains
+                           invalid datetime/UUID values.
+    """
+    try:
+        raw = base64.urlsafe_b64decode(token.encode()).decode()
+    except Exception as exc:
+        raise InvalidInputError("invalid nextToken (base64 decode failed)") from exc
+
+    parts = raw.split(_CURSOR_SEP, 1)
+    if len(parts) != 2:
+        raise InvalidInputError("invalid nextToken (missing separator)")
+
+    ts_str, id_str = parts
+    try:
+        created_at = datetime.fromisoformat(ts_str)
+        # Ensure timezone-aware for SQL comparison.
+        if created_at.tzinfo is None:
+            created_at = created_at.replace(tzinfo=UTC)
+    except ValueError as exc:
+        raise InvalidInputError(f"invalid nextToken (bad datetime: {ts_str!r})") from exc
+
+    try:
+        id_uuid = uuid.UUID(id_str)
+    except ValueError as exc:
+        raise InvalidInputError(f"invalid nextToken (bad UUID: {id_str!r})") from exc
+
+    return created_at, id_uuid
+
+
+class ValidDevice(NamedTuple):
+    """A device that passed FSM and availability validation."""
+
+    device_id: str  # UUID as string
+    state_id: int
+
+
+class InvalidDevice(NamedTuple):
+    """A device that failed FSM or availability validation."""
+
+    device_id: str  # UUID as string
+    reason: str  # human-readable; includes error-code prefix e.g. "DEVICE_NOT_FOUND: ..."
+
+
+class ExecutionTuple(NamedTuple):
+    """Row returned from action_executions INSERT."""
+
+    device_id: str  # UUID as string
+    execution_id: str  # action_executions.id
+    command_uuid: str  # action_executions.command_uuid
+
+
+class Database:
+    """psycopg3 connection bound to a single Lambda invocation.
+
+    Context-manager only — do not use outside ``with Database() as db:``.
+    All schema-qualified SQL uses ``psycopg.sql.Identifier`` — never f-string.
+
+    Raises:
+        DatabaseError: If the initial connection fails.
+    """
+
+    def __init__(self) -> None:
+        self._conn: psycopg.Connection[Any] | None = None
+
+    def __enter__(self) -> Database:
+        try:
+            self._conn = psycopg.connect(DATABASE_URI, row_factory=psycopg.rows.dict_row)
+        except psycopg.Error as exc:
+            logger.exception("db.connect_failed")
+            raise DatabaseError("database connection failed") from exc
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        if self._conn is not None:
+            try:
+                self._conn.close()
+            except psycopg.Error:
+                logger.warning("db.close_failed")
+            finally:
+                self._conn = None
+
+    # ------------------------------------------------------------------
+    # accesscontrol helpers (shared with auth.py)
+    # ------------------------------------------------------------------
+
+    def get_schema_name(self, tenant_id: int) -> str:
+        """Resolve tenant BIGINT id → validated schema name.
+
+        Args:
+            tenant_id: The tenant id from the Cognito auth claim.
+
+        Returns:
+            Validated schema name (e.g. ``"dev1"``).
+
+        Raises:
+            TenantNotFoundError: No row exists for tenant_id.
+            DatabaseError: Query failed or schema name fails regex.
+        """
+        conn = self._require_conn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT schema_name FROM accesscontrol.tenants WHERE id = %s",
+                    (tenant_id,),
+                )
+                row = cur.fetchone()
+        except psycopg.Error as exc:
+            logger.exception("db.get_schema_name_failed", extra={"tenant_id": tenant_id})
+            raise DatabaseError("tenant lookup failed") from exc
+
+        if not row:
+            raise TenantNotFoundError(str(tenant_id))
+
+        return _validate_schema(str(row["schema_name"]))
+
+    def has_permission(self, cognito_sub: str, tenant_id: int, code: str) -> bool:
+        """Return True if user holds permission code for the tenant (or globally).
+
+        Args:
+            cognito_sub: User's Cognito subject claim.
+            tenant_id:   Tenant BIGINT id.
+            code:        Permission code (e.g. ``"action:execute"``).
+
+        Raises:
+            DatabaseError: Query execution failed.
+        """
+        conn = self._require_conn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT 1
+                    FROM accesscontrol.users u
+                    JOIN accesscontrol.users_permissions up ON u.id = up.user_id
+                    JOIN accesscontrol.permissions p       ON p.id = up.permission_id
+                    WHERE u.cognito_sub = %s
+                      AND p.code = %s
+                      AND (up.tenant_id = %s OR up.tenant_id IS NULL)
+                    LIMIT 1
+                    """,
+                    (cognito_sub, code, tenant_id),
+                )
+                return cur.fetchone() is not None
+        except psycopg.Error as exc:
+            logger.exception(
+                "db.has_permission_failed",
+                extra={"cognito_sub": cognito_sub, "code": code},
+            )
+            raise DatabaseError("permission check failed") from exc
+
+    # ------------------------------------------------------------------
+    # Action-resolver repo methods
+    # ------------------------------------------------------------------
+
+    def load_action(self, action_id: str, schema: str) -> dict[str, Any] | None:
+        """Load an action row by UUID from the tenant schema.
+
+        Args:
+            action_id: UUID string of the action.
+            schema:    Validated tenant schema name.
+
+        Returns:
+            Row dict with at minimum ``{id, from_state_id}`` or None if not found.
+
+        Raises:
+            DatabaseError: Query failed.
+        """
+        _validate_schema(schema)
+        conn = self._require_conn()
+        query = psycopg.sql.SQL(
+            "SELECT id, name, from_state_id, action_type_id, apply_policy_id "
+            "FROM {schema}.actions WHERE id = %s"
+        ).format(schema=psycopg.sql.Identifier(schema))
+        try:
+            with conn.cursor() as cur:
+                cur.execute(query, (action_id,))
+                row = cur.fetchone()
+        except psycopg.Error as exc:
+            logger.exception("db.load_action_failed", extra={"action_id": action_id})
+            raise DatabaseError("load_action query failed") from exc
+        return dict(row) if row else None
+
+    def load_message_template(self, template_id: str, schema: str) -> dict[str, Any] | None:
+        """Load a message_template row by UUID from the tenant schema.
+
+        Args:
+            template_id: UUID string of the template.
+            schema:      Validated tenant schema name.
+
+        Returns:
+            Row dict with at minimum ``{id, content, is_active}`` or None if not found.
+
+        Raises:
+            DatabaseError: Query failed.
+        """
+        _validate_schema(schema)
+        conn = self._require_conn()
+        query = psycopg.sql.SQL(
+            "SELECT id, name, content, is_active, notification_type "
+            "FROM {schema}.message_templates WHERE id = %s"
+        ).format(schema=psycopg.sql.Identifier(schema))
+        try:
+            with conn.cursor() as cur:
+                cur.execute(query, (template_id,))
+                row = cur.fetchone()
+        except psycopg.Error as exc:
+            logger.exception("db.load_message_template_failed", extra={"template_id": template_id})
+            raise DatabaseError("load_message_template query failed") from exc
+        return dict(row) if row else None
+
+    def validate_devices_for_action(
+        self,
+        device_ids: list[str],
+        action_id: str,
+        schema: str,
+    ) -> tuple[list[ValidDevice], list[InvalidDevice]]:
+        """Classify devices into valid/invalid for the given action.
+
+        Performs a single JOIN query to fetch device state and action's
+        from_state_id, then classifies in Python:
+          - Not found → ``InvalidDevice(reason="DEVICE_NOT_FOUND: ...")``.
+          - state_id != action.from_state_id → ``InvalidDevice(reason="INVALID_TRANSITION: ...")``.
+          - Valid (assigned_action_id check is deferred to the race-safe UPDATE).
+
+        NOTE: ``assigned_action_id IS NULL`` is NOT checked here — that race-safe
+        check is done in ``create_batch_with_devices`` via UPDATE...WHERE...RETURNING.
+
+        Args:
+            device_ids: List of device UUID strings.
+            action_id:  Action UUID string.
+            schema:     Validated tenant schema name.
+
+        Returns:
+            (valid_devices, invalid_devices) tuple.
+
+        Raises:
+            DatabaseError: Query failed.
+        """
+        _validate_schema(schema)
+        conn = self._require_conn()
+
+        query = psycopg.sql.SQL(
+            """
+            SELECT d.id, d.state_id, d.assigned_action_id, a.from_state_id
+            FROM   {schema}.devices d
+            JOIN   {schema}.actions a ON a.id = %s
+            WHERE  d.id = ANY(%s)
+            """
+        ).format(schema=psycopg.sql.Identifier(schema))
+
+        try:
+            with conn.cursor() as cur:
+                cur.execute(query, (action_id, device_ids))
+                rows = cur.fetchall()
+        except psycopg.Error as exc:
+            logger.exception(
+                "db.validate_devices_failed",
+                extra={"action_id": action_id, "count": len(device_ids)},
+            )
+            raise DatabaseError("validate_devices_for_action query failed") from exc
+
+        found_ids = {str(row["id"]) for row in rows}
+        valid: list[ValidDevice] = []
+        invalid: list[InvalidDevice] = []
+
+        # Devices not returned by the query are not found in this tenant.
+        for did in device_ids:
+            if did not in found_ids:
+                invalid.append(
+                    InvalidDevice(device_id=did, reason=f"DEVICE_NOT_FOUND: device {did} not found")
+                )
+
+        for row in rows:
+            did = str(row["id"])
+            state_id = int(row["state_id"])
+            from_state_id = row["from_state_id"]
+
+            # from_state_id may be NULL for Upload action (state-agnostic).
+            if from_state_id is not None and state_id != int(from_state_id):
+                invalid.append(
+                    InvalidDevice(
+                        device_id=did,
+                        reason=(
+                            f"INVALID_TRANSITION: device state {state_id} "
+                            f"does not match action from_state {from_state_id}"
+                        ),
+                    )
+                )
+            else:
+                valid.append(ValidDevice(device_id=did, state_id=state_id))
+
+        return valid, invalid
+
+    def create_batch_with_devices(
+        self,
+        batch_id: str,
+        action_id: str,
+        created_by: str,
+        valid_devices: list[ValidDevice],
+        schema: str,
+    ) -> list[ExecutionTuple]:
+        """Insert batch_actions + batch_device_actions + action_executions in one transaction.
+
+        Race-safe: uses ``UPDATE devices SET assigned_action_id=... WHERE id=ANY(...)
+        AND assigned_action_id IS NULL RETURNING id`` — only locked device IDs
+        proceed to INSERT; devices that lost the race are silently excluded here
+        (caller gets empty ExecutionTuple for those device_ids and handles them
+        as DEVICE_BUSY failures).
+
+        All INSERTs happen inside a single psycopg transaction block.
+        On any psycopg error the transaction is rolled back.
+
+        Args:
+            batch_id:      UUID string for the batch (batch_actions.batch_id).
+            action_id:     Action UUID string.
+            created_by:    cognito_sub of the requesting user.
+            valid_devices: Devices that passed FSM validation.
+            schema:        Validated tenant schema name.
+
+        Returns:
+            List of ExecutionTuple for devices that were successfully locked.
+            Devices that lost the concurrent-assign race are absent from the list.
+
+        Raises:
+            DatabaseError: Any DB error during the transaction; transaction is rolled back.
+        """
+        _validate_schema(schema)
+        conn = self._require_conn()
+
+        if not valid_devices:
+            return []
+
+        device_ids = [d.device_id for d in valid_devices]
+        # Generate a new batch PK uuid (batch_actions.id) separate from batch_id
+        batch_pk = str(uuid.uuid4())
+
+        try:
+            with conn.transaction():
+                # 1. Race-safe device lock: only returns IDs that were unassigned.
+                lock_query = psycopg.sql.SQL(
+                    """
+                    UPDATE {schema}.devices
+                    SET    assigned_action_id = %s
+                    WHERE  id = ANY(%s)
+                      AND  assigned_action_id IS NULL
+                    RETURNING id
+                    """
+                ).format(schema=psycopg.sql.Identifier(schema))
+
+                with conn.cursor() as cur:
+                    cur.execute(lock_query, (action_id, device_ids))
+                    locked_rows = cur.fetchall()
+
+                locked_ids = {str(r["id"]) for r in locked_rows}
+                locked_devices = [d for d in valid_devices if d.device_id in locked_ids]
+
+                if not locked_devices:
+                    # All lost the race — nothing to insert; transaction commits empty.
+                    return []
+
+                locked_count = len(locked_devices)
+
+                # 2. INSERT batch_actions (one row per batch).
+                ba_query = psycopg.sql.SQL(
+                    """
+                    INSERT INTO {schema}.batch_actions
+                        (id, batch_id, action_id, created_by, total_devices, status)
+                    VALUES (%s, %s, %s, %s, %s, 'IN_PROGRESS')
+                    """
+                ).format(schema=psycopg.sql.Identifier(schema))
+
+                with conn.cursor() as cur:
+                    cur.execute(ba_query, (batch_pk, batch_id, action_id, created_by, locked_count))
+
+                # 3. INSERT action_executions and batch_device_actions per locked device.
+                ae_query = psycopg.sql.SQL(
+                    """
+                    INSERT INTO {schema}.action_executions (device_id, action_id, status)
+                    VALUES (%s, %s, 'ACTION_PENDING')
+                    RETURNING id, command_uuid
+                    """
+                ).format(schema=psycopg.sql.Identifier(schema))
+
+                bda_query = psycopg.sql.SQL(
+                    """
+                    INSERT INTO {schema}.batch_device_actions (batch_id, device_id, status)
+                    VALUES (%s, %s, 'PENDING')
+                    """
+                ).format(schema=psycopg.sql.Identifier(schema))
+
+                results: list[ExecutionTuple] = []
+                for device in locked_devices:
+                    with conn.cursor() as cur:
+                        cur.execute(ae_query, (device.device_id, action_id))
+                        ae_row = cur.fetchone()
+
+                    if not ae_row:
+                        raise DatabaseError(
+                            f"action_executions INSERT returned no row for device {device.device_id}"
+                        )
+
+                    with conn.cursor() as cur:
+                        cur.execute(bda_query, (batch_id, device.device_id))
+
+                    results.append(
+                        ExecutionTuple(
+                            device_id=device.device_id,
+                            execution_id=str(ae_row["id"]),
+                            command_uuid=str(ae_row["command_uuid"]),
+                        )
+                    )
+
+            return results
+
+        except psycopg.Error as exc:
+            logger.exception(
+                "db.create_batch_with_devices_failed",
+                extra={"batch_id": batch_id, "action_id": action_id},
+            )
+            raise DatabaseError("create_batch_with_devices transaction failed") from exc
+
+    # ------------------------------------------------------------------
+    # ActionLog repo methods (P1b)
+    # ------------------------------------------------------------------
+
+    def get_action_log_by_batch_id(self, batch_id: str, schema: str) -> dict[str, Any] | None:
+        """Load a batch_actions row by batch_id UUID with computed errorCount.
+
+        Args:
+            batch_id: UUID string (``batch_actions.batch_id``).
+            schema:   Validated tenant schema name.
+
+        Returns:
+            Row dict with keys: id, batch_id, action_id, created_by, total_devices,
+            error_count, status, created_at.  Returns None if not found.
+
+        Raises:
+            DatabaseError: Query failed.
+        """
+        _validate_schema(schema)
+        conn = self._require_conn()
+        query = psycopg.sql.SQL(
+            """
+            SELECT ba.id,
+                   ba.batch_id,
+                   ba.action_id,
+                   ba.created_by,
+                   ba.total_devices,
+                   ba.status,
+                   ba.created_at,
+                   COUNT(bda.id) FILTER (WHERE bda.error_code IS NOT NULL) AS error_count
+            FROM   {schema}.batch_actions ba
+            LEFT JOIN {schema}.batch_device_actions bda ON bda.batch_id = ba.batch_id
+            WHERE  ba.batch_id = %s
+            GROUP BY ba.id
+            """
+        ).format(schema=psycopg.sql.Identifier(schema))
+        try:
+            with conn.cursor() as cur:
+                cur.execute(query, (batch_id,))
+                row = cur.fetchone()
+        except psycopg.Error as exc:
+            logger.exception("db.get_action_log_failed", extra={"batch_id": batch_id})
+            raise DatabaseError("get_action_log_by_batch_id query failed") from exc
+        return dict(row) if row else None
+
+    def list_action_logs(
+        self,
+        limit: int,
+        after_cursor: str | None,
+        schema: str,
+    ) -> tuple[list[dict[str, Any]], str | None]:
+        """List batch_actions with computed errorCount, ordered newest-first.
+
+        Uses a tuple cursor ``(created_at DESC, id DESC)`` for stable pagination
+        under ties.  Fetches N+1 rows to determine whether a next page exists.
+
+        Args:
+            limit:        Page size (max rows to return to caller).
+            after_cursor: Opaque nextToken from a previous response, or None
+                          for the first page.
+            schema:       Validated tenant schema name.
+
+        Returns:
+            (rows, next_cursor) where next_cursor is None if no more pages.
+
+        Raises:
+            InvalidInputError: Cursor is malformed.
+            DatabaseError:     Query failed.
+        """
+        _validate_schema(schema)
+        conn = self._require_conn()
+
+        cursor_filter = psycopg.sql.SQL("")
+        cursor_params: tuple[Any, ...] = ()
+
+        if after_cursor:
+            cur_created_at, cur_id = _decode_action_log_cursor(after_cursor)
+            cursor_filter = psycopg.sql.SQL(
+                "AND (ba.created_at, ba.id) < (%s::timestamptz, %s::uuid)"
+            )
+            cursor_params = (cur_created_at.isoformat(), str(cur_id))
+
+        query = psycopg.sql.SQL(
+            """
+            SELECT ba.id,
+                   ba.batch_id,
+                   ba.action_id,
+                   ba.created_by,
+                   ba.total_devices,
+                   ba.status,
+                   ba.created_at,
+                   COUNT(bda.id) FILTER (WHERE bda.error_code IS NOT NULL) AS error_count
+            FROM   {schema}.batch_actions ba
+            LEFT JOIN {schema}.batch_device_actions bda ON bda.batch_id = ba.batch_id
+            WHERE  TRUE
+            {cursor_filter}
+            GROUP BY ba.id
+            ORDER BY ba.created_at DESC, ba.id DESC
+            LIMIT  %s
+            """
+        ).format(
+            schema=psycopg.sql.Identifier(schema),
+            cursor_filter=cursor_filter,
+        )
+
+        params: tuple[Any, ...] = cursor_params + (limit + 1,)
+
+        try:
+            with conn.cursor() as cur:
+                cur.execute(query, params)
+                rows = cur.fetchall()
+        except psycopg.Error as exc:
+            logger.exception("db.list_action_logs_failed")
+            raise DatabaseError("list_action_logs query failed") from exc
+
+        raw_rows = [dict(r) for r in rows]
+        has_more = len(raw_rows) > limit
+        page = raw_rows[:limit]
+
+        next_cursor: str | None = None
+        if has_more and page:
+            last = page[-1]
+            next_cursor = _encode_action_log_cursor(last["created_at"], last["id"])
+
+        return page, next_cursor
+
+    def get_failed_devices_for_batch(self, batch_id: str, schema: str) -> list[dict[str, Any]]:
+        """Return failed batch_device_actions rows for CSV report generation.
+
+        Args:
+            batch_id: UUID string (``batch_device_actions.batch_id``).
+            schema:   Validated tenant schema name.
+
+        Returns:
+            List of dicts with keys: device_id, error_code, error_message, finished_at.
+            Empty list if no failed rows exist.
+
+        Raises:
+            DatabaseError: Query failed.
+        """
+        _validate_schema(schema)
+        conn = self._require_conn()
+        query = psycopg.sql.SQL(
+            """
+            SELECT device_id, error_code, error_message, finished_at
+            FROM   {schema}.batch_device_actions
+            WHERE  batch_id = %s
+              AND  error_code IS NOT NULL
+            ORDER BY finished_at
+            """
+        ).format(schema=psycopg.sql.Identifier(schema))
+        try:
+            with conn.cursor() as cur:
+                cur.execute(query, (batch_id,))
+                rows = cur.fetchall()
+        except psycopg.Error as exc:
+            logger.exception("db.get_failed_devices_failed", extra={"batch_id": batch_id})
+            raise DatabaseError("get_failed_devices_for_batch query failed") from exc
+        return [dict(r) for r in rows]
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _require_conn(self) -> psycopg.Connection[Any]:
+        if self._conn is None:
+            raise DatabaseError("Database used outside context manager")
+        return self._conn

--- a/fluxion-backend/modules/action_resolver/src/exceptions.py
+++ b/fluxion-backend/modules/action_resolver/src/exceptions.py
@@ -1,0 +1,187 @@
+"""Domain exceptions for action_resolver Lambda.
+
+All errors extend ``FluxionError`` so the handler boundary catches one type
+and maps to AppSync error responses consistently (design-patterns.md §4).
+
+``to_appsync_error()`` on the base produces ``{"errorType", "errorMessage"}``
+as expected by AppSync Lambda direct resolvers.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class FluxionError(Exception):
+    """Base class for all Fluxion domain errors.
+
+    Subclasses set ``code`` and ``http_status`` as class attributes.
+    The handler catches ``FluxionError`` and calls ``to_appsync_error()``.
+
+    Args:
+        message: Human-readable error description.
+    """
+
+    code: str = "INTERNAL_ERROR"
+    http_status: int = 500
+
+    def to_appsync_error(self) -> dict[str, Any]:
+        """Serialize to AppSync Lambda direct resolver error shape.
+
+        Returns:
+            ``{"errorType": <code>, "errorMessage": <message>}`` dict.
+        """
+        return {
+            "errorType": self.code,
+            "errorMessage": str(self) or self.code,
+        }
+
+
+class DatabaseError(FluxionError):
+    """Database operation failed (connection, query, constraint)."""
+
+    code = "DATABASE_ERROR"
+    http_status = 503
+
+
+class TenantNotFoundError(FluxionError):
+    """Tenant id has no matching row in ``accesscontrol.tenants``."""
+
+    code = "TENANT_NOT_FOUND"
+    http_status = 404
+
+
+class NotFoundError(FluxionError):
+    """Requested resource does not exist."""
+
+    code = "NOT_FOUND"
+    http_status = 404
+
+
+class ForbiddenError(FluxionError):
+    """Caller lacks a required permission."""
+
+    code = "FORBIDDEN"
+    http_status = 403
+
+
+class AuthenticationError(FluxionError):
+    """Identity claims missing or unresolvable."""
+
+    code = "UNAUTHENTICATED"
+    http_status = 401
+
+
+class InvalidInputError(FluxionError):
+    """Client-supplied input failed validation."""
+
+    code = "INVALID_INPUT"
+    http_status = 400
+
+
+class UnknownFieldError(FluxionError):
+    """GraphQL field name not registered in ``FIELD_HANDLERS``."""
+
+    code = "UNKNOWN_FIELD"
+    http_status = 400
+
+
+# ---------------------------------------------------------------------------
+# Action-resolver-specific errors
+# ---------------------------------------------------------------------------
+
+
+class ActionNotFoundError(FluxionError):
+    """Requested action does not exist in the tenant schema.
+
+    Raised before the per-device loop so the whole request fails fast.
+    """
+
+    code = "ACTION_NOT_FOUND"
+    http_status = 404
+
+
+class TemplateNotFoundError(FluxionError):
+    """messageTemplateId references a template that does not exist.
+
+    Raised before the per-device loop; whole-request failure.
+    """
+
+    code = "TEMPLATE_NOT_FOUND"
+    http_status = 404
+
+
+class TemplateArchivedError(FluxionError):
+    """Template exists but ``is_active = FALSE`` — cannot be used.
+
+    Raised before the per-device loop; whole-request failure.
+    """
+
+    code = "TEMPLATE_ARCHIVED"
+    http_status = 422
+
+
+class InvalidStateError(FluxionError):
+    """Device state does not match ``action.from_state_id`` (FSM violation).
+
+    Per-device failure for ``assignAction``.
+    Encoded as reason string in ``BulkAssignError`` for bulk path.
+    """
+
+    code = "INVALID_TRANSITION"
+    http_status = 422
+
+
+class DeviceAlreadyAssignedError(FluxionError):
+    """Device already has an assigned action (race-safe detection post-UPDATE).
+
+    Per-device failure for ``assignAction``.
+    Encoded as reason string in ``BulkAssignError`` for bulk path.
+    """
+
+    code = "DEVICE_BUSY"
+    http_status = 409
+
+
+class SqsError(FluxionError):
+    """SQS SendMessage failed.
+
+    Raised by ``sqs.py``; callers log and suppress after DB commit so the
+    request succeeds and rows remain PENDING for the action-trigger consumer
+    to surface via ActionLog error reporting (P1b).
+    """
+
+    code = "SQS_ERROR"
+    http_status = 503
+
+
+class BatchNotFoundError(FluxionError):
+    """Batch UUID does not exist in ``batch_actions``.
+
+    Used by ``generateActionLogErrorReport`` when no batch row is found.
+    """
+
+    code = "BATCH_NOT_FOUND"
+    http_status = 404
+
+
+class S3Error(FluxionError):
+    """S3 operation failed (PutObject or presign).
+
+    Raised by ``s3.py``; callers should surface to AppSync as INTERNAL_ERROR.
+    """
+
+    code = "S3_ERROR"
+    http_status = 503
+
+
+def to_appsync_error(exc: FluxionError) -> dict[str, Any]:
+    """Functional alias for ``exc.to_appsync_error()``.
+
+    Args:
+        exc: Any ``FluxionError`` subclass instance.
+
+    Returns:
+        ``{"errorType": <code>, "errorMessage": <message>}`` dict.
+    """
+    return exc.to_appsync_error()

--- a/fluxion-backend/modules/action_resolver/src/handler.py
+++ b/fluxion-backend/modules/action_resolver/src/handler.py
@@ -1,0 +1,509 @@
+"""Lambda entry point — AppSync field dispatch for action_resolver.
+
+Fields handled:
+  assignAction(input: AssignActionInput!)                        → AssignActionResponse!
+  assignBulkAction(input: BulkAssignInput!)                      → BulkAssignResponse!
+  getActionLog(batchId: ID!)                                     → ActionLog
+  listActionLogs(limit: Int, nextToken: String)                  → ActionLogConnection!
+  generateActionLogErrorReport(batchId: ID!)                     → ActionLogErrorReport!
+
+Both assign mutations share a common implementation path (_assign_impl) that:
+  1. Optionally loads a message template (validates is_active).
+  2. Loads the action (validates existence).
+  3. Validates devices via FSM state check (SQL JOIN).
+  4. Writes batch_actions + batch_device_actions + action_executions
+     in a single transaction with race-safe device locking.
+  5. Sends one SQS message per locked device (post-commit; failures logged, not re-raised).
+
+assignAction is a degenerate single-device case: raises on any per-device failure.
+assignBulkAction collects per-device failures into failed[] and returns partial success.
+
+Architectural note (GH-35 decision #9): batchId is internal SQS routing only;
+it is never returned to the GraphQL caller. AssignActionResponse contains only
+{executionId, commandUuid, status}.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from auth import Context, permission_required, validate_input
+from config import logger
+from csv_render import render_failed_devices_csv
+from db import Database, ExecutionTuple, InvalidDevice
+from exceptions import (
+    ActionNotFoundError,
+    BatchNotFoundError,
+    DeviceAlreadyAssignedError,
+    FluxionError,
+    InvalidStateError,
+    NotFoundError,
+    SqsError,
+    TemplateArchivedError,
+    TemplateNotFoundError,
+    UnknownFieldError,
+)
+from permissions import PERM_ACTION_EXECUTE, PERM_ACTIONLOG_READ
+from s3 import presigned_get_url, put_csv
+from schema_types import (
+    ActionLogConnectionResponse,
+    ActionLogErrorReportResponse,
+    ActionLogResponse,
+    AssignActionInput,
+    AssignActionResponse,
+    BulkAssignError,
+    BulkAssignInput,
+    BulkAssignResponse,
+    GenerateErrorReportInput,
+    GetActionLogInput,
+    ListActionLogsInput,
+)
+from sqs import enqueue_action_trigger
+
+FieldHandler = Callable[[dict[str, Any], Any, str], Any]
+
+
+# ---------------------------------------------------------------------------
+# Shared implementation
+# ---------------------------------------------------------------------------
+
+
+def _load_template_content(template_id: str, schema: str, db: Database) -> str:
+    """Load and validate a message template, returning its content string.
+
+    Args:
+        template_id: UUID string of the message template.
+        schema:      Tenant schema name.
+        db:          Open Database instance.
+
+    Returns:
+        Template content string (plain text injected into SQS payload).
+
+    Raises:
+        TemplateNotFoundError: Template UUID does not exist.
+        TemplateArchivedError: Template exists but is_active = FALSE.
+    """
+    row = db.load_message_template(template_id, schema)
+    if row is None:
+        raise TemplateNotFoundError(f"message template {template_id!r} not found")
+    if not row["is_active"]:
+        raise TemplateArchivedError(
+            f"message template {template_id!r} is archived (is_active=FALSE)"
+        )
+    return str(row["content"])
+
+
+def _build_sqs_envelope(
+    *,
+    batch_id: str,
+    device_id: str,
+    action_id: str,
+    execution_id: str,
+    command_uuid: str,
+    configuration: dict[str, Any] | None,
+    message_content: str | None,
+    tenant_schema: str,
+) -> dict[str, Any]:
+    """Construct the SQS message envelope (GH-35 architectural decision #9)."""
+    envelope: dict[str, Any] = {
+        "batchId": batch_id,
+        "deviceId": device_id,
+        "actionId": action_id,
+        "executionId": execution_id,
+        "commandUuid": command_uuid,
+        "configuration": configuration,
+        "tenant_schema": tenant_schema,
+    }
+    if message_content is not None:
+        envelope["messageContent"] = message_content
+    return envelope
+
+
+def _assign_impl(
+    *,
+    device_ids: list[str],
+    action_id: str,
+    configuration: dict[str, Any] | None,
+    message_template_id: str | None,
+    ctx: Context,
+    correlation_id: str,
+) -> tuple[list[ExecutionTuple], list[InvalidDevice]]:
+    """Core assign logic shared by assignAction and assignBulkAction.
+
+    Steps (all inside a single Database connection):
+      1. Optionally load + validate message template.
+      2. Load action → ActionNotFoundError if missing.
+      3. Validate devices for FSM state match → split valid/invalid.
+      4. create_batch_with_devices (single transaction + race-safe UPDATE).
+      5. Devices missing from ExecutionTuple results (lost race) → DEVICE_BUSY failures.
+
+    Args:
+        device_ids:          List of device UUID strings to assign.
+        action_id:           Action UUID string.
+        configuration:       Optional JSON payload forwarded to SQS consumer.
+        message_template_id: Optional template UUID string.
+        ctx:                 Resolved caller context.
+        correlation_id:      AWS request ID for tracing.
+
+    Returns:
+        (executions, all_invalid) where executions are successfully committed
+        rows and all_invalid aggregates FSM + race failures.
+    """
+    schema = ctx.tenant_schema
+    batch_id = str(uuid.uuid4())
+    message_content: str | None = None
+
+    with Database() as db:
+        # Step 1: optionally load message template (whole-request failure).
+        if message_template_id is not None:
+            message_content = _load_template_content(message_template_id, schema, db)
+
+        # Step 2: load action (whole-request failure).
+        action_row = db.load_action(action_id, schema)
+        if action_row is None:
+            raise ActionNotFoundError(f"action {action_id!r} not found")
+
+        # Step 3: classify devices by FSM state.
+        valid_devices, invalid_devices = db.validate_devices_for_action(
+            device_ids, action_id, schema
+        )
+
+        # Step 4: write batch in a single transaction with race-safe locking.
+        executions = db.create_batch_with_devices(
+            batch_id=batch_id,
+            action_id=action_id,
+            created_by=ctx.cognito_sub,
+            valid_devices=valid_devices,
+            schema=schema,
+        )
+
+    # Step 5: devices in valid_devices but absent from executions lost the race.
+    executed_ids = {e.device_id for e in executions}
+    race_losers: list[InvalidDevice] = [
+        InvalidDevice(
+            device_id=d.device_id,
+            reason=f"DEVICE_BUSY: device {d.device_id} already has an assigned action",
+        )
+        for d in valid_devices
+        if d.device_id not in executed_ids
+    ]
+    all_invalid = list(invalid_devices) + race_losers
+
+    # Step 6: SQS enqueue per successfully committed device (post-commit).
+    # Failures are logged and suppressed — DB commit already occurred.
+    for ex in executions:
+        envelope = _build_sqs_envelope(
+            batch_id=batch_id,
+            device_id=ex.device_id,
+            action_id=action_id,
+            execution_id=ex.execution_id,
+            command_uuid=ex.command_uuid,
+            configuration=configuration,
+            message_content=message_content,
+            tenant_schema=schema,
+        )
+        try:
+            msg_id = enqueue_action_trigger(envelope)
+            logger.info(
+                "sqs.enqueued",
+                extra={
+                    "device_id": ex.device_id,
+                    "execution_id": ex.execution_id,
+                    "sqs_message_id": msg_id,
+                    "correlation_id": correlation_id,
+                },
+            )
+        except SqsError:
+            # Post-commit SQS failure: row stays PENDING; ActionLog error report (P1b) flags it.
+            logger.error(
+                "sqs.enqueue_failed_post_commit",
+                extra={
+                    "device_id": ex.device_id,
+                    "execution_id": ex.execution_id,
+                    "batch_id": batch_id,
+                    "correlation_id": correlation_id,
+                },
+            )
+
+    return executions, all_invalid
+
+
+# ---------------------------------------------------------------------------
+# Field handlers
+# ---------------------------------------------------------------------------
+
+
+@permission_required(PERM_ACTION_EXECUTE)
+@validate_input(AssignActionInput, key="input")
+def assign_action(
+    _args: dict[str, Any], ctx: Context, correlation_id: str, inp: AssignActionInput
+) -> dict[str, Any]:
+    """Handle assignAction mutation — single device assignment.
+
+    Raises a domain error if the device fails any validation (FSM mismatch,
+    not found, already assigned). Does NOT return a partial-success response.
+
+    Args:
+        _args:          Raw arguments dict (pre-parsed via validate_input).
+        ctx:            Resolved caller context (injected by permission_required).
+        correlation_id: AWS request ID for tracing.
+        inp:            Validated AssignActionInput.
+
+    Returns:
+        AssignActionResponse dict matching GraphQL type.
+
+    Raises:
+        ActionNotFoundError:       Action UUID not found.
+        TemplateNotFoundError:     Template UUID not found.
+        TemplateArchivedError:     Template is archived.
+        NotFoundError:             Device UUID not found.
+        InvalidStateError:         Device FSM state mismatch.
+        DeviceAlreadyAssignedError: Device lost the race (already assigned).
+    """
+    device_id = str(inp.deviceId)
+    action_id = str(inp.actionId)
+    template_id = str(inp.messageTemplateId) if inp.messageTemplateId else None
+
+    executions, all_invalid = _assign_impl(
+        device_ids=[device_id],
+        action_id=action_id,
+        configuration=inp.configuration,
+        message_template_id=template_id,
+        ctx=ctx,
+        correlation_id=correlation_id,
+    )
+
+    # Single-device path: raise on any per-device failure.
+    if all_invalid:
+        reason = all_invalid[0].reason
+        if reason.startswith("DEVICE_NOT_FOUND"):
+            raise NotFoundError(f"device {device_id} not found in tenant {ctx.tenant_schema}")
+        if reason.startswith("INVALID_TRANSITION"):
+            raise InvalidStateError(reason)
+        if reason.startswith("DEVICE_BUSY"):
+            raise DeviceAlreadyAssignedError(reason)
+        # Fallback for unexpected reason strings.
+        raise FluxionError(reason)
+
+    if not executions:
+        # Should not happen after all_invalid is empty, but guard for safety.
+        raise DeviceAlreadyAssignedError(f"device {device_id} could not be assigned")
+
+    ex = executions[0]
+    return AssignActionResponse.dump_execution(
+        execution_id=ex.execution_id,
+        command_uuid=ex.command_uuid,
+    )
+
+
+@permission_required(PERM_ACTION_EXECUTE)
+@validate_input(BulkAssignInput, key="input")
+def assign_bulk_action(
+    _args: dict[str, Any], ctx: Context, correlation_id: str, inp: BulkAssignInput
+) -> dict[str, Any]:
+    """Handle assignBulkAction mutation — N device assignments with partial success.
+
+    Whole-request failures (ActionNotFoundError, TemplateNotFoundError,
+    TemplateArchivedError) propagate as FluxionErrors and return error dicts.
+    Per-device failures are collected into ``failed[]`` in the response.
+
+    Args:
+        _args:          Raw arguments dict (pre-parsed via validate_input).
+        ctx:            Resolved caller context (injected by permission_required).
+        correlation_id: AWS request ID for tracing.
+        inp:            Validated BulkAssignInput.
+
+    Returns:
+        BulkAssignResponse dict matching GraphQL type.
+    """
+    device_ids = [str(d) for d in inp.deviceIds]
+    action_id = str(inp.actionId)
+    template_id = str(inp.messageTemplateId) if inp.messageTemplateId else None
+
+    executions, all_invalid = _assign_impl(
+        device_ids=device_ids,
+        action_id=action_id,
+        configuration=inp.configuration,
+        message_template_id=template_id,
+        ctx=ctx,
+        correlation_id=correlation_id,
+    )
+
+    valid_responses = [
+        AssignActionResponse.from_execution(
+            execution_id=ex.execution_id,
+            command_uuid=ex.command_uuid,
+        )
+        for ex in executions
+    ]
+
+    failed_responses = [
+        BulkAssignError.from_device(device_id=inv.device_id, reason=inv.reason)
+        for inv in all_invalid
+    ]
+
+    return BulkAssignResponse.build(valid=valid_responses, failed=failed_responses).model_dump()
+
+
+# ---------------------------------------------------------------------------
+# ActionLog read handlers (P1b)
+# ---------------------------------------------------------------------------
+
+_CSV_KEY_PREFIX = "action-log-errors"
+_PRESIGN_TTL = 300  # 5 minutes
+
+
+@permission_required(PERM_ACTIONLOG_READ)
+@validate_input(GetActionLogInput)
+def get_action_log(
+    _args: dict[str, Any], ctx: Context, correlation_id: str, inp: GetActionLogInput
+) -> dict[str, Any] | None:
+    """Handle getActionLog(batchId: ID!) → ActionLog (null if not found).
+
+    Returns None (AppSync null) when the batch doesn't exist — NOT an error.
+
+    Args:
+        _args:          Raw arguments dict.
+        ctx:            Caller context.
+        correlation_id: AWS request ID.
+        inp:            Validated GetActionLogInput.
+
+    Returns:
+        ActionLogResponse dict or None if batch not found.
+    """
+    with Database() as db:
+        row = db.get_action_log_by_batch_id(inp.batchId, ctx.tenant_schema)
+
+    if row is None:
+        return None
+
+    return ActionLogResponse.from_row(row).model_dump()
+
+
+@permission_required(PERM_ACTIONLOG_READ)
+@validate_input(ListActionLogsInput)
+def list_action_logs(
+    _args: dict[str, Any], ctx: Context, correlation_id: str, inp: ListActionLogsInput
+) -> dict[str, Any]:
+    """Handle listActionLogs(limit, nextToken) → ActionLogConnection!.
+
+    Args:
+        _args:          Raw arguments dict.
+        ctx:            Caller context.
+        correlation_id: AWS request ID.
+        inp:            Validated ListActionLogsInput.
+
+    Returns:
+        ActionLogConnectionResponse dict matching GraphQL type.
+    """
+    with Database() as db:
+        rows, next_cursor = db.list_action_logs(
+            limit=inp.limit,
+            after_cursor=inp.nextToken,
+            schema=ctx.tenant_schema,
+        )
+
+    items = [ActionLogResponse.from_row(r) for r in rows]
+    return ActionLogConnectionResponse(items=items, nextToken=next_cursor).model_dump()
+
+
+@permission_required(PERM_ACTIONLOG_READ)
+@validate_input(GenerateErrorReportInput)
+def generate_action_log_error_report(
+    _args: dict[str, Any],
+    ctx: Context,
+    correlation_id: str,
+    inp: GenerateErrorReportInput,
+) -> dict[str, Any]:
+    """Handle generateActionLogErrorReport(batchId: ID!) → ActionLogErrorReport!.
+
+    Steps:
+      1. Verify batch exists (BatchNotFoundError if missing).
+      2. Fetch failed device rows.
+      3. Render CSV (header-only if 0 failed rows — do NOT raise).
+      4. Upload to S3 at action-log-errors/{batchId}.csv.
+      5. Generate 5-min presigned GET URL.
+      6. Return {batchId, url, expiresAt}.
+
+    Args:
+        _args:          Raw arguments dict.
+        ctx:            Caller context.
+        correlation_id: AWS request ID.
+        inp:            Validated GenerateErrorReportInput.
+
+    Returns:
+        ActionLogErrorReportResponse dict matching GraphQL type.
+
+    Raises:
+        BatchNotFoundError: No batch_actions row for batchId.
+        S3Error:            Upload or presign failed.
+    """
+    batch_id = inp.batchId
+
+    with Database() as db:
+        batch = db.get_action_log_by_batch_id(batch_id, ctx.tenant_schema)
+        if batch is None:
+            raise BatchNotFoundError(f"batch {batch_id!r} not found")
+
+        failed_rows = db.get_failed_devices_for_batch(batch_id, ctx.tenant_schema)
+
+    csv_bytes = render_failed_devices_csv(failed_rows)
+    key = f"{_CSV_KEY_PREFIX}/{batch_id}.csv"
+
+    put_csv(key, csv_bytes)
+
+    url = presigned_get_url(key, ttl_seconds=_PRESIGN_TTL)
+    expires_at = (datetime.now(UTC) + timedelta(seconds=_PRESIGN_TTL)).isoformat()
+
+    logger.info(
+        "action_log.error_report_generated",
+        extra={
+            "batch_id": batch_id,
+            "key": key,
+            "failed_count": len(failed_rows),
+            "correlation_id": correlation_id,
+        },
+    )
+
+    return ActionLogErrorReportResponse(
+        batchId=batch_id,
+        url=url,
+        expiresAt=expires_at,
+    ).model_dump()
+
+
+# ---------------------------------------------------------------------------
+# Dispatch table + entry point
+# ---------------------------------------------------------------------------
+
+FIELD_HANDLERS: dict[str, FieldHandler] = {
+    "assignAction": assign_action,
+    "assignBulkAction": assign_bulk_action,
+    "getActionLog": get_action_log,
+    "listActionLogs": list_action_logs,
+    "generateActionLogErrorReport": generate_action_log_error_report,
+}
+
+
+def lambda_handler(event: dict[str, Any], context: Any) -> Any:
+    """AppSync Lambda direct resolver entry point."""
+    correlation_id: str = getattr(context, "aws_request_id", "local")
+    field: str = event.get("info", {}).get("fieldName", "")
+
+    logger.info("resolver.invoked", extra={"field": field, "correlation_id": correlation_id})
+
+    try:
+        handler = FIELD_HANDLERS.get(field)
+        if handler is None:
+            raise UnknownFieldError(f"no handler for field: {field!r}")
+        result: Any = handler(event.get("arguments", {}), event, correlation_id)
+        return result
+    except FluxionError as exc:
+        logger.warning(
+            "resolver.error",
+            extra={"field": field, "error_type": exc.code, "correlation_id": correlation_id},
+        )
+        return exc.to_appsync_error()

--- a/fluxion-backend/modules/action_resolver/src/permissions.py
+++ b/fluxion-backend/modules/action_resolver/src/permissions.py
@@ -1,0 +1,14 @@
+"""Permission codes for action_resolver.
+
+Must match rows seeded by the permission catalog migration into
+``accesscontrol.permissions`` (seeded in P0 of GH-35).
+
+Codes:
+  action:execute   — assignAction, assignBulkAction (P1a)
+  actionlog:read   — getActionLog, listActionLogs, generateActionLogErrorReport (P1b)
+"""
+
+from __future__ import annotations
+
+PERM_ACTION_EXECUTE = "action:execute"
+PERM_ACTIONLOG_READ = "actionlog:read"

--- a/fluxion-backend/modules/action_resolver/src/s3.py
+++ b/fluxion-backend/modules/action_resolver/src/s3.py
@@ -1,0 +1,98 @@
+"""Thin S3 wrapper for action_resolver — CSV upload + presigned GET URL.
+
+Client is lazily initialized (same pattern as sqs.py) to avoid import-time
+AWS SDK initialization in test environments.
+
+Errors from boto3 are caught and re-raised as S3Error so callers get a
+uniform FluxionError.
+
+Security note: log only the S3 key — never the presigned URL (may contain
+credentials as query parameters).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from config import UPLOADS_BUCKET, logger
+from exceptions import S3Error
+
+if TYPE_CHECKING:
+    import botocore.exceptions  # noqa: F401  (type-checking import only)
+
+# Module-level lazy singleton — avoids boto3 import at cold-start in tests.
+_client: Any = None
+
+
+def _get_client() -> Any:
+    """Return (or create) the module-level boto3 S3 client."""
+    global _client  # noqa: PLW0603
+    if _client is None:
+        import boto3  # deferred — not available in unit-test environments
+
+        _client = boto3.client("s3")
+    return _client
+
+
+def put_csv(key: str, body: bytes, bucket: str | None = None) -> None:
+    """Upload CSV bytes to S3.
+
+    Args:
+        key:    S3 object key (e.g. ``"action-log-errors/{batchId}.csv"``).
+        body:   Raw bytes to upload (UTF-8 + BOM CSV).
+        bucket: Override bucket name; defaults to ``UPLOADS_BUCKET`` env var.
+
+    Raises:
+        S3Error: boto3 ClientError or any unexpected exception during upload.
+    """
+    effective_bucket = bucket or UPLOADS_BUCKET
+    client = _get_client()
+    try:
+        client.put_object(
+            Bucket=effective_bucket,
+            Key=key,
+            Body=body,
+            ContentType="text/csv",
+        )
+        logger.info("s3.put_csv_success", extra={"bucket": effective_bucket, "key": key})
+    except Exception as exc:
+        # Catch botocore.exceptions.ClientError and any other boto3 error.
+        logger.exception("s3.put_csv_failed", extra={"bucket": effective_bucket, "key": key})
+        raise S3Error(f"S3 put_object failed for key {key!r}: {exc}") from exc
+
+
+def presigned_get_url(
+    key: str,
+    ttl_seconds: int = 300,
+    bucket: str | None = None,
+) -> str:
+    """Generate a pre-signed GET URL for an S3 object.
+
+    Args:
+        key:         S3 object key.
+        ttl_seconds: URL expiry in seconds (default 5 minutes).
+        bucket:      Override bucket name; defaults to ``UPLOADS_BUCKET`` env var.
+
+    Returns:
+        Pre-signed HTTPS URL string.
+
+    Raises:
+        S3Error: boto3 ClientError or any unexpected exception during presign.
+    """
+    effective_bucket = bucket or UPLOADS_BUCKET
+    client = _get_client()
+    try:
+        url: str = client.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": effective_bucket, "Key": key},
+            ExpiresIn=ttl_seconds,
+        )
+        # Log key only — never log the URL (contains signed credentials).
+        logger.info(
+            "s3.presigned_url_generated",
+            extra={"bucket": effective_bucket, "key": key, "ttl_seconds": ttl_seconds},
+        )
+        return url
+    except Exception as exc:
+        logger.exception("s3.presign_failed", extra={"bucket": effective_bucket, "key": key})
+        raise S3Error(f"S3 presign failed for key {key!r}: {exc}") from exc

--- a/fluxion-backend/modules/action_resolver/src/schema_types.py
+++ b/fluxion-backend/modules/action_resolver/src/schema_types.py
@@ -1,0 +1,312 @@
+"""Pydantic v2 DTOs for action_resolver — shaped to match schema.graphql exactly.
+
+AppSync receives whatever model_dump() emits, so field names MUST match
+GraphQL type field names (camelCase).
+
+GraphQL types handled:
+
+  type AssignActionResponse {
+    executionId: ID!
+    commandUuid: ID!
+    status: ActionStatus!
+  }
+
+  type BulkAssignResponse {
+    valid: [AssignActionResponse!]!
+    failed: [BulkAssignError!]!
+  }
+
+  type BulkAssignError {
+    deviceId: ID!
+    reason: String!
+  }
+
+  type ActionLog {
+    id: ID!
+    batchId: ID!
+    actionId: ID!
+    created_by: String!
+    totalDevices: Int!
+    errorCount: Int!
+    status: ActionLogStatus!
+    created_at: AWSDateTime!
+  }
+
+  type ActionLogConnection {
+    items: [ActionLog!]!
+    nextToken: String
+  }
+
+  type ActionLogErrorReport {
+    batchId: ID!
+    url: String!
+    expiresAt: AWSDateTime!
+  }
+
+  input AssignActionInput {
+    deviceId: ID!
+    actionId: ID!
+    configuration: AWSJSON
+    messageTemplateId: ID
+  }
+
+  input BulkAssignInput {
+    deviceIds: [ID!]!
+    actionId: ID!
+    configuration: AWSJSON
+    messageTemplateId: ID
+  }
+
+Notes:
+  - ``ActionStatus`` here is just a string matching the DB enum
+    (ACTION_PENDING at creation time).
+  - ``batchId`` is internal only for assign mutations — not returned.
+  - ``configuration`` is AWSJSON in schema (arbitrary JSON); accept as dict or None.
+  - ActionLog has mixed snake_case (created_by, created_at) and camelCase fields —
+    declared with matching Python attribute names so model_dump() emits the right keys.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+# ---------------------------------------------------------------------------
+# Cursor input models (for listActionLogs / getActionLog / generateErrorReport)
+# ---------------------------------------------------------------------------
+
+
+class GetActionLogInput(BaseModel):
+    """Input parsed from getActionLog(batchId: ID!) arguments."""
+
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    batchId: str
+
+
+class ListActionLogsInput(BaseModel):
+    """Input parsed from listActionLogs(limit, nextToken) arguments."""
+
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    limit: int = 20
+    nextToken: str | None = None
+
+    @field_validator("limit")
+    @classmethod
+    def _bound_limit(cls, v: int) -> int:
+        if v < 1 or v > 100:
+            raise ValueError(f"limit must be between 1 and 100 (got {v})")
+        return v
+
+
+class GenerateErrorReportInput(BaseModel):
+    """Input parsed from generateActionLogErrorReport(batchId: ID!) arguments."""
+
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    batchId: str
+
+
+class BaseInput(BaseModel):
+    """Strict input base — unknown fields rejected immediately."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class BaseResponse(BaseModel):
+    """Permissive response base — forward-compatible with new server fields."""
+
+    model_config = ConfigDict(extra="allow")
+
+
+# ---------------------------------------------------------------------------
+# Input models
+# ---------------------------------------------------------------------------
+
+
+class AssignActionInput(BaseInput):
+    """Input for assignAction mutation.
+
+    Attributes:
+        deviceId:          Target device UUID.
+        actionId:          Action UUID (must exist in tenant schema).
+        configuration:     Arbitrary JSON payload forwarded to SQS consumer.
+        messageTemplateId: Optional template UUID; when set, content is loaded
+                           and injected as ``messageContent`` in the SQS envelope.
+    """
+
+    deviceId: UUID
+    actionId: UUID
+    configuration: dict[str, Any] | None = None
+    messageTemplateId: UUID | None = None
+
+
+class BulkAssignInput(BaseInput):
+    """Input for assignBulkAction mutation.
+
+    Attributes:
+        deviceIds:         Non-empty list of device UUIDs (max 500).
+        actionId:          Action UUID (must exist in tenant schema).
+        configuration:     Arbitrary JSON payload forwarded to SQS consumer.
+        messageTemplateId: Optional template UUID; same semantics as single assign.
+    """
+
+    deviceIds: list[UUID]
+    actionId: UUID
+    configuration: dict[str, Any] | None = None
+    messageTemplateId: UUID | None = None
+
+    @field_validator("deviceIds")
+    @classmethod
+    def validate_device_ids(cls, v: list[UUID]) -> list[UUID]:
+        if not v:
+            raise ValueError("deviceIds must contain at least one device")
+        if len(v) > 500:
+            raise ValueError(f"deviceIds exceeds maximum of 500 (got {len(v)})")
+        return v
+
+
+# ---------------------------------------------------------------------------
+# Response models
+# ---------------------------------------------------------------------------
+
+
+class AssignActionResponse(BaseResponse):
+    """Single-device assignment result — matches GraphQL AssignActionResponse.
+
+    Attributes:
+        executionId: ``action_executions.id`` UUID for this execution.
+        commandUuid: ``action_executions.command_uuid`` — unique command identity
+                     used by the action-trigger consumer.
+        status:      Always ``ACTION_PENDING`` at creation time.
+    """
+
+    executionId: str  # UUID as string → GraphQL ID
+    commandUuid: str  # UUID as string → GraphQL ID
+    status: str  # ActionStatus enum value
+
+    @classmethod
+    def from_execution(
+        cls,
+        execution_id: str,
+        command_uuid: str,
+        status: str = "ACTION_PENDING",
+    ) -> AssignActionResponse:
+        """Build response from execution tuple fields."""
+        return cls(executionId=execution_id, commandUuid=command_uuid, status=status)
+
+    @classmethod
+    def dump_execution(
+        cls,
+        execution_id: str,
+        command_uuid: str,
+        status: str = "ACTION_PENDING",
+    ) -> dict[str, Any]:
+        """Build and immediately serialize to dict."""
+        return cls.from_execution(execution_id, command_uuid, status).model_dump()
+
+
+class BulkAssignError(BaseResponse):
+    """Per-device failure entry — matches GraphQL BulkAssignError.
+
+    Attributes:
+        deviceId: The device UUID that could not be assigned.
+        reason:   Human-readable failure reason (includes error code prefix,
+                  e.g. ``"DEVICE_BUSY: already assigned to action X"``).
+    """
+
+    deviceId: str  # UUID as string → GraphQL ID
+    reason: str
+
+    @classmethod
+    def from_device(cls, device_id: str, reason: str) -> BulkAssignError:
+        return cls(deviceId=device_id, reason=reason)
+
+
+class BulkAssignResponse(BaseResponse):
+    """Bulk assignment result — matches GraphQL BulkAssignResponse.
+
+    Attributes:
+        valid:  Successfully assigned devices with execution details.
+        failed: Per-device failures (FSM mismatch, busy, not found).
+    """
+
+    valid: list[AssignActionResponse]
+    failed: list[BulkAssignError]
+
+    @classmethod
+    def build(
+        cls,
+        valid: list[AssignActionResponse],
+        failed: list[BulkAssignError],
+    ) -> BulkAssignResponse:
+        return cls(valid=valid, failed=failed)
+
+
+# ---------------------------------------------------------------------------
+# ActionLog response models (P1b)
+# ---------------------------------------------------------------------------
+
+
+class ActionLogResponse(BaseResponse):
+    """Matches GraphQL type ActionLog.
+
+    IMPORTANT: GraphQL field names are mixed snake_case + camelCase.
+    Python attribute names MUST match GraphQL names so model_dump() emits
+    the correct keys for AppSync:
+      - snake_case:  created_by, created_at
+      - camelCase:   id, batchId, actionId, totalDevices, errorCount, status
+
+    model_config uses populate_by_name=True to allow construction by
+    both alias and attribute name (psycopg dict_row uses snake names).
+    """
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    id: str
+    batchId: str
+    actionId: str
+    created_by: str
+    totalDevices: int
+    errorCount: int
+    status: str
+    created_at: str  # ISO-8601 string; psycopg returns datetime, handler converts
+
+    @classmethod
+    def from_row(cls, row: dict[str, Any]) -> ActionLogResponse:
+        """Build from a psycopg dict_row (snake_case DB columns → mixed GQL fields).
+
+        Expected keys: id, batch_id, action_id, created_by, total_devices,
+                       error_count, status, created_at.
+        """
+        created_at = row["created_at"]
+        return cls(
+            id=str(row["id"]),
+            batchId=str(row["batch_id"]),
+            actionId=str(row["action_id"]),
+            created_by=str(row["created_by"]),
+            totalDevices=int(row["total_devices"]),
+            errorCount=int(row["error_count"]),
+            status=str(row["status"]),
+            created_at=created_at.isoformat()
+            if hasattr(created_at, "isoformat")
+            else str(created_at),
+        )
+
+
+class ActionLogConnectionResponse(BaseResponse):
+    """Matches GraphQL type ActionLogConnection."""
+
+    items: list[ActionLogResponse]
+    nextToken: str | None = None
+
+
+class ActionLogErrorReportResponse(BaseResponse):
+    """Matches GraphQL type ActionLogErrorReport."""
+
+    batchId: str
+    url: str
+    expiresAt: str  # ISO-8601 datetime string (AWSDateTime)

--- a/fluxion-backend/modules/action_resolver/src/sqs.py
+++ b/fluxion-backend/modules/action_resolver/src/sqs.py
@@ -1,0 +1,89 @@
+"""Thin boto3 SQS wrapper for action_resolver.
+
+Sends action-trigger messages to the configured SQS queue.
+Each message envelope (locked in GH-35 architectural decision #9):
+
+    {
+      "batchId":        <str UUID>,
+      "deviceId":       <str UUID>,
+      "actionId":       <str UUID>,
+      "executionId":    <str UUID>,
+      "commandUuid":    <str UUID>,
+      "configuration":  <dict | null>,
+      "messageContent": <str | null>,   # only present when messageTemplateId was provided
+      "tenant_schema":  <str>
+    }
+
+SQS errors after DB commit are logged but NOT re-raised to the handler —
+the user request already succeeded. Dead PENDING rows are surfaced by the
+ActionLog error report (P1b). See phase-01a-action-resolver-assign.md.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from config import ACTION_TRIGGER_QUEUE_URL, logger
+from exceptions import SqsError
+
+# Lazy-init client: instantiated on first send, reused within the Lambda container.
+_client: Any = None
+
+
+def _get_client() -> Any:
+    """Return (or create) the boto3 SQS client.
+
+    Lazy init avoids import-time boto3 calls during unit tests.
+    """
+    global _client  # noqa: PLW0603
+    if _client is None:
+        import boto3  # deferred to avoid import cost when SQS is not needed
+
+        _client = boto3.client("sqs")
+    return _client
+
+
+def enqueue_action_trigger(message_body: dict[str, Any], queue_url: str | None = None) -> str:
+    """Send a single action-trigger message to SQS.
+
+    Args:
+        message_body: Dict conforming to the SQS envelope schema (see module docstring).
+        queue_url:    Override queue URL (used in tests); defaults to ACTION_TRIGGER_QUEUE_URL.
+
+    Returns:
+        SQS ``MessageId`` string.
+
+    Raises:
+        SqsError: boto3 ``ClientError`` from SQS; caller should catch, log, and
+                  continue — the DB commit has already occurred.
+    """
+    url = queue_url or ACTION_TRIGGER_QUEUE_URL
+    try:
+        response: dict[str, Any] = _get_client().send_message(
+            QueueUrl=url,
+            MessageBody=json.dumps(message_body),
+        )
+        return str(response["MessageId"])
+    except Exception as exc:
+        # Import botocore lazily — it's always present when boto3 is installed.
+        try:
+            from botocore.exceptions import ClientError
+
+            if isinstance(exc, ClientError):
+                logger.error(
+                    "sqs.send_message_failed",
+                    extra={
+                        "device_id": message_body.get("deviceId"),
+                        "batch_id": message_body.get("batchId"),
+                        "error": str(exc),
+                    },
+                )
+                raise SqsError(f"SQS send_message failed: {exc}") from exc
+        except ImportError:
+            pass
+        logger.error(
+            "sqs.send_message_unexpected_error",
+            extra={"error": str(exc)},
+        )
+        raise SqsError(f"SQS send_message unexpected error: {exc}") from exc

--- a/fluxion-backend/modules/action_resolver/tests/conftest.py
+++ b/fluxion-backend/modules/action_resolver/tests/conftest.py
@@ -1,0 +1,23 @@
+"""Shared pytest fixtures for action_resolver Lambda tests.
+
+The autouse session fixture sets the minimum env vars required so that
+importing config.py does not fail during collection. No real DB or SQS needed.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _set_env() -> None:
+    """Set required environment variables for the test session."""
+    os.environ.setdefault("LOG_LEVEL", "DEBUG")
+    os.environ.setdefault("POWERTOOLS_SERVICE_NAME", "action_resolver-test")
+    os.environ.setdefault("DATABASE_URI", "postgresql://localhost/test")
+    os.environ.setdefault(
+        "ACTION_TRIGGER_QUEUE_URL", "https://sqs.us-east-1.amazonaws.com/000000000000/test-queue"
+    )
+    os.environ.setdefault("UPLOADS_BUCKET", "fluxion-dev-uploads")

--- a/fluxion-backend/modules/action_resolver/tests/test_assign_bulk.py
+++ b/fluxion-backend/modules/action_resolver/tests/test_assign_bulk.py
@@ -1,0 +1,270 @@
+"""Focused tests for race-safe bulk assignment and partial-failure split.
+
+These tests verify the _assign_impl split logic directly:
+  - All devices valid, all locked → all in valid[]
+  - Some devices fail FSM → in failed[] with INVALID_TRANSITION
+  - Some devices not found → in failed[] with DEVICE_NOT_FOUND
+  - Some devices pass FSM but lose UPDATE race → in failed[] with DEVICE_BUSY
+  - Mixed: FSM invalid + race loser + not-found + success
+  - Whole batch: all devices are race losers → valid=[], failed has all with DEVICE_BUSY
+  - assignAction single device raises DeviceAlreadyAssignedError on race loss
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from db import ExecutionTuple, InvalidDevice, ValidDevice
+from handler import _assign_impl
+
+# ---------------------------------------------------------------------------
+# Context stub
+# ---------------------------------------------------------------------------
+
+
+def _make_ctx(schema: str = "dev1", cognito_sub: str = "sub-test") -> MagicMock:
+    ctx = MagicMock()
+    ctx.tenant_schema = schema
+    ctx.cognito_sub = cognito_sub
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# DB mock factory for _assign_impl
+# ---------------------------------------------------------------------------
+
+
+def _make_db_mock(
+    action_row: dict[str, Any] | None = None,
+    template_row: dict[str, Any] | None = None,
+    valid_devices: list[ValidDevice] | None = None,
+    invalid_devices: list[InvalidDevice] | None = None,
+    executions: list[ExecutionTuple] | None = None,
+) -> MagicMock:
+    db = MagicMock()
+    db.__enter__ = MagicMock(return_value=db)
+    db.__exit__ = MagicMock(return_value=False)
+    db.load_action.return_value = action_row or {"id": "act-1", "from_state_id": 4}
+    db.load_message_template.return_value = template_row
+    db.validate_devices_for_action.return_value = (
+        valid_devices if valid_devices is not None else [],
+        invalid_devices if invalid_devices is not None else [],
+    )
+    db.create_batch_with_devices.return_value = executions if executions is not None else []
+    return db
+
+
+def _run_impl(
+    device_ids: list[str],
+    db_mock: MagicMock,
+    action_id: str | None = None,
+    template_id: str | None = None,
+) -> tuple[list[ExecutionTuple], list[InvalidDevice]]:
+    ctx = _make_ctx()
+    with (
+        patch("handler.Database", return_value=db_mock),
+        patch("handler.enqueue_action_trigger", return_value="msg-id"),
+        patch("handler.uuid") as mock_uuid,
+    ):
+        mock_uuid.uuid4.return_value = uuid.UUID("00000000-0000-0000-0000-000000000001")
+        return _assign_impl(
+            device_ids=device_ids,
+            action_id=action_id or str(uuid.uuid4()),
+            configuration=None,
+            message_template_id=template_id,
+            ctx=ctx,
+            correlation_id="test-cid",
+        )
+
+
+# ---------------------------------------------------------------------------
+# All valid, all locked
+# ---------------------------------------------------------------------------
+
+
+def test_all_devices_valid_and_locked() -> None:
+    """All devices pass FSM and all are locked → executions == input count, failed empty."""
+    dev1 = str(uuid.uuid4())
+    dev2 = str(uuid.uuid4())
+    exe1 = str(uuid.uuid4())
+    exe2 = str(uuid.uuid4())
+    cmd1 = str(uuid.uuid4())
+    cmd2 = str(uuid.uuid4())
+
+    db = _make_db_mock(
+        valid_devices=[ValidDevice(dev1, 4), ValidDevice(dev2, 4)],
+        invalid_devices=[],
+        executions=[ExecutionTuple(dev1, exe1, cmd1), ExecutionTuple(dev2, exe2, cmd2)],
+    )
+    executions, invalid = _run_impl([dev1, dev2], db)
+
+    assert len(executions) == 2
+    assert invalid == []
+    executed_ids = {e.device_id for e in executions}
+    assert dev1 in executed_ids
+    assert dev2 in executed_ids
+
+
+# ---------------------------------------------------------------------------
+# FSM invalid
+# ---------------------------------------------------------------------------
+
+
+def test_fsm_invalid_devices_go_to_failed() -> None:
+    """Devices that fail FSM check → all in invalid, none in executions."""
+    dev1 = str(uuid.uuid4())
+    db = _make_db_mock(
+        valid_devices=[],
+        invalid_devices=[InvalidDevice(dev1, "INVALID_TRANSITION: state 1 != from_state 4")],
+        executions=[],
+    )
+    executions, invalid = _run_impl([dev1], db)
+
+    assert executions == []
+    assert len(invalid) == 1
+    assert invalid[0].device_id == dev1
+    assert "INVALID_TRANSITION" in invalid[0].reason
+
+
+# ---------------------------------------------------------------------------
+# Device not found
+# ---------------------------------------------------------------------------
+
+
+def test_device_not_found_goes_to_failed() -> None:
+    """Devices absent from DB query result → DEVICE_NOT_FOUND in invalid."""
+    dev1 = str(uuid.uuid4())
+    db = _make_db_mock(
+        valid_devices=[],
+        invalid_devices=[InvalidDevice(dev1, f"DEVICE_NOT_FOUND: device {dev1} not found")],
+        executions=[],
+    )
+    executions, invalid = _run_impl([dev1], db)
+
+    assert executions == []
+    assert len(invalid) == 1
+    assert "DEVICE_NOT_FOUND" in invalid[0].reason
+
+
+# ---------------------------------------------------------------------------
+# Race-safe: all race losers
+# ---------------------------------------------------------------------------
+
+
+def test_all_devices_lose_race() -> None:
+    """All pass FSM but none locked by UPDATE → executions empty, all DEVICE_BUSY in failed."""
+    dev1 = str(uuid.uuid4())
+    dev2 = str(uuid.uuid4())
+
+    db = _make_db_mock(
+        valid_devices=[ValidDevice(dev1, 4), ValidDevice(dev2, 4)],
+        invalid_devices=[],
+        executions=[],  # UPDATE RETURNING returned nothing
+    )
+    executions, invalid = _run_impl([dev1, dev2], db)
+
+    assert executions == []
+    assert len(invalid) == 2
+    for inv in invalid:
+        assert "DEVICE_BUSY" in inv.reason
+
+
+# ---------------------------------------------------------------------------
+# Race-safe: partial race loss
+# ---------------------------------------------------------------------------
+
+
+def test_partial_race_loss_splits_correctly() -> None:
+    """One device wins the lock, one loses → 1 in executions, 1 DEVICE_BUSY in failed."""
+    dev1 = str(uuid.uuid4())
+    dev2 = str(uuid.uuid4())
+    exe1 = str(uuid.uuid4())
+    cmd1 = str(uuid.uuid4())
+
+    db = _make_db_mock(
+        valid_devices=[ValidDevice(dev1, 4), ValidDevice(dev2, 4)],
+        invalid_devices=[],
+        # dev2 absent from executions → race loser
+        executions=[ExecutionTuple(dev1, exe1, cmd1)],
+    )
+    executions, invalid = _run_impl([dev1, dev2], db)
+
+    assert len(executions) == 1
+    assert executions[0].device_id == dev1
+    assert len(invalid) == 1
+    assert invalid[0].device_id == dev2
+    assert "DEVICE_BUSY" in invalid[0].reason
+
+
+# ---------------------------------------------------------------------------
+# Mixed: FSM invalid + race loser + not-found + success
+# ---------------------------------------------------------------------------
+
+
+def test_mixed_failure_modes() -> None:
+    """Four devices: 1 success, 1 FSM-invalid, 1 not-found, 1 race-loser."""
+    dev_ok = str(uuid.uuid4())
+    dev_fsm = str(uuid.uuid4())
+    dev_missing = str(uuid.uuid4())
+    dev_race = str(uuid.uuid4())
+    exe_ok = str(uuid.uuid4())
+    cmd_ok = str(uuid.uuid4())
+
+    db = _make_db_mock(
+        valid_devices=[ValidDevice(dev_ok, 4), ValidDevice(dev_race, 4)],
+        invalid_devices=[
+            InvalidDevice(dev_fsm, "INVALID_TRANSITION: state 1 != from_state 4"),
+            InvalidDevice(dev_missing, f"DEVICE_NOT_FOUND: device {dev_missing} not found"),
+        ],
+        # dev_race lost the UPDATE race
+        executions=[ExecutionTuple(dev_ok, exe_ok, cmd_ok)],
+    )
+    executions, invalid = _run_impl([dev_ok, dev_fsm, dev_missing, dev_race], db)
+
+    assert len(executions) == 1
+    assert executions[0].device_id == dev_ok
+
+    reasons = {inv.device_id: inv.reason for inv in invalid}
+    assert "INVALID_TRANSITION" in reasons[dev_fsm]
+    assert "DEVICE_NOT_FOUND" in reasons[dev_missing]
+    assert "DEVICE_BUSY" in reasons[dev_race]
+
+
+# ---------------------------------------------------------------------------
+# SQS failure suppression in bulk path
+# ---------------------------------------------------------------------------
+
+
+def test_sqs_failure_suppressed_in_bulk_path() -> None:
+    """SQS failure post-commit is logged but not surfaced in valid/failed split."""
+    from sqs import SqsError
+
+    dev1 = str(uuid.uuid4())
+    exe1 = str(uuid.uuid4())
+    cmd1 = str(uuid.uuid4())
+    ctx = _make_ctx()
+
+    db = _make_db_mock(
+        valid_devices=[ValidDevice(dev1, 4)],
+        executions=[ExecutionTuple(dev1, exe1, cmd1)],
+    )
+    with (
+        patch("handler.Database", return_value=db),
+        patch("handler.enqueue_action_trigger", side_effect=SqsError("queue down")),
+        patch("handler.uuid") as mock_uuid,
+    ):
+        mock_uuid.uuid4.return_value = uuid.UUID("00000000-0000-0000-0000-000000000002")
+        executions, invalid = _assign_impl(
+            device_ids=[dev1],
+            action_id=str(uuid.uuid4()),
+            configuration=None,
+            message_template_id=None,
+            ctx=ctx,
+            correlation_id="cid",
+        )
+
+    # DB commit succeeded; SQS failure does not move device to failed[]
+    assert len(executions) == 1
+    assert invalid == []

--- a/fluxion-backend/modules/action_resolver/tests/test_csv_render.py
+++ b/fluxion-backend/modules/action_resolver/tests/test_csv_render.py
@@ -1,0 +1,100 @@
+"""Tests for csv_render.render_failed_devices_csv."""
+
+from __future__ import annotations
+
+import csv
+import io
+
+from csv_render import render_failed_devices_csv
+
+_BOM = b"\xef\xbb\xbf"
+_EXPECTED_HEADER = "device_id,error_code,error_message,finished_at"
+
+
+def _parse_csv(data: bytes) -> list[list[str]]:
+    """Strip BOM and parse CSV bytes to list of row lists."""
+    text = data.decode("utf-8-sig")  # utf-8-sig strips BOM on decode
+    reader = csv.reader(io.StringIO(text))
+    return list(reader)
+
+
+class TestRenderFailedDevicesCsv:
+    def test_bom_present(self) -> None:
+        result = render_failed_devices_csv([])
+        assert result.startswith(_BOM), "CSV must start with UTF-8 BOM (0xEF 0xBB 0xBF)"
+
+    def test_header_only_on_empty_rows(self) -> None:
+        result = render_failed_devices_csv([])
+        rows = _parse_csv(result)
+        assert rows == [["device_id", "error_code", "error_message", "finished_at"]]
+
+    def test_header_columns_correct_order(self) -> None:
+        result = render_failed_devices_csv([])
+        # raw text after BOM
+        text = result.decode("utf-8-sig")
+        first_line = text.split("\n")[0]
+        assert first_line == _EXPECTED_HEADER
+
+    def test_single_row(self) -> None:
+        rows = [
+            {
+                "device_id": "dev-001",
+                "error_code": "TIMEOUT",
+                "error_message": "device timed out",
+                "finished_at": "2026-04-26T10:00:00+00:00",
+            }
+        ]
+        result = render_failed_devices_csv(rows)
+        parsed = _parse_csv(result)
+        assert len(parsed) == 2  # header + 1 data row
+        assert parsed[1] == ["dev-001", "TIMEOUT", "device timed out", "2026-04-26T10:00:00+00:00"]
+
+    def test_multiple_rows(self) -> None:
+        rows = [
+            {
+                "device_id": f"dev-{i}",
+                "error_code": "ERR",
+                "error_message": f"error {i}",
+                "finished_at": "2026-01-01T00:00:00+00:00",
+            }
+            for i in range(5)
+        ]
+        result = render_failed_devices_csv(rows)
+        parsed = _parse_csv(result)
+        assert len(parsed) == 6  # header + 5 rows
+        assert parsed[0] == ["device_id", "error_code", "error_message", "finished_at"]
+        assert parsed[1][0] == "dev-0"
+        assert parsed[5][0] == "dev-4"
+
+    def test_missing_keys_become_empty_string(self) -> None:
+        """Defensive: partial dicts should not raise."""
+        rows = [{"device_id": "dev-x"}]
+        result = render_failed_devices_csv(rows)
+        parsed = _parse_csv(result)
+        assert parsed[1] == ["dev-x", "", "", ""]
+
+    def test_returns_bytes(self) -> None:
+        result = render_failed_devices_csv([])
+        assert isinstance(result, bytes)
+
+    def test_newline_terminator(self) -> None:
+        """Lines must end with \\n not \\r\\n."""
+        result = render_failed_devices_csv([])
+        assert b"\r\n" not in result
+
+    def test_excel_round_trip(self) -> None:
+        """Simulate Excel opening: decode with utf-8-sig strips BOM cleanly."""
+        rows = [
+            {
+                "device_id": "abc",
+                "error_code": "CODE",
+                "error_message": "msg with, comma",
+                "finished_at": "2026-04-26T00:00:00Z",
+            }
+        ]
+        result = render_failed_devices_csv(rows)
+        text = result.decode("utf-8-sig")
+        reader = csv.reader(io.StringIO(text))
+        parsed = list(reader)
+        # comma in message_content must be quoted by csv.writer
+        assert parsed[1][2] == "msg with, comma"

--- a/fluxion-backend/modules/action_resolver/tests/test_db.py
+++ b/fluxion-backend/modules/action_resolver/tests/test_db.py
@@ -1,0 +1,630 @@
+"""Tests for action_resolver db.py — Database wrapper and repo methods.
+
+Uses unittest.mock to simulate psycopg3 connections; no real PostgreSQL needed.
+Covers:
+  - get_schema_name: happy path, tenant not found, query error
+  - has_permission: granted, denied, query error
+  - load_action: found, not found, query error
+  - load_message_template: found, not found, query error
+  - validate_devices_for_action: all valid, FSM mismatch, device not found, mixed
+  - create_batch_with_devices: happy path, all-race-loser, empty input, db error
+  - _require_conn: used outside context manager raises DatabaseError
+  - _validate_schema: bad names rejected
+  - get_action_log_by_batch_id: found, not found, query error
+  - list_action_logs: first page, with cursor, has_more, empty
+  - get_failed_devices_for_batch: with rows, empty, query error
+  - cursor helpers: encode/decode round-trip, bad token, missing separator, bad uuid
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from db import (
+    Database,
+    ValidDevice,
+    _decode_action_log_cursor,
+    _encode_action_log_cursor,
+    _validate_schema,
+)
+from exceptions import DatabaseError, InvalidInputError, TenantNotFoundError
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+SCHEMA = "dev1"
+ACTION_ID = str(uuid.uuid4())
+DEVICE_ID = str(uuid.uuid4())
+TEMPLATE_ID = str(uuid.uuid4())
+BATCH_ID = str(uuid.uuid4())
+EXECUTION_ID = str(uuid.uuid4())
+COMMAND_UUID_VAL = str(uuid.uuid4())
+
+
+def _make_conn(
+    fetchone_returns: list[Any] | None = None,
+    fetchall_returns: list[Any] | None = None,
+    execute_raises: Exception | None = None,
+) -> MagicMock:
+    """Build a mock psycopg3 connection with a cursor sequence."""
+    conn = MagicMock()
+    conn.__enter__ = MagicMock(return_value=conn)
+    conn.__exit__ = MagicMock(return_value=False)
+
+    cursor = MagicMock()
+    cursor.__enter__ = MagicMock(return_value=cursor)
+    cursor.__exit__ = MagicMock(return_value=False)
+
+    if execute_raises is not None:
+        cursor.execute.side_effect = execute_raises
+    if fetchone_returns is not None:
+        cursor.fetchone.side_effect = fetchone_returns
+    if fetchall_returns is not None:
+        cursor.fetchall.side_effect = fetchall_returns
+
+    conn.cursor.return_value = cursor
+    return conn
+
+
+def _open_db(conn: MagicMock) -> Database:
+    """Return a Database with _conn already set (bypasses psycopg.connect)."""
+    db = Database.__new__(Database)
+    db._conn = conn  # type: ignore[attr-defined]
+    return db
+
+
+# ---------------------------------------------------------------------------
+# _validate_schema
+# ---------------------------------------------------------------------------
+
+
+def test_validate_schema_valid_names() -> None:
+    assert _validate_schema("dev1") == "dev1"
+    assert _validate_schema("a") == "a"
+    assert _validate_schema("abc_123") == "abc_123"
+
+
+def test_validate_schema_rejects_invalid() -> None:
+    with pytest.raises(DatabaseError):
+        _validate_schema("1invalid")
+    with pytest.raises(DatabaseError):
+        _validate_schema("has space")
+    with pytest.raises(DatabaseError):
+        _validate_schema("")
+    with pytest.raises(DatabaseError):
+        _validate_schema("UPPER")
+
+
+# ---------------------------------------------------------------------------
+# get_schema_name
+# ---------------------------------------------------------------------------
+
+
+def test_get_schema_name_returns_validated_name() -> None:
+    conn = _make_conn(fetchone_returns=[{"schema_name": "dev1"}])
+    db = _open_db(conn)
+    result = db.get_schema_name(1)
+    assert result == "dev1"
+
+
+def test_get_schema_name_tenant_not_found() -> None:
+    conn = _make_conn(fetchone_returns=[None])
+    db = _open_db(conn)
+    with pytest.raises(TenantNotFoundError):
+        db.get_schema_name(99)
+
+
+def test_get_schema_name_query_error_raises_database_error() -> None:
+    import psycopg
+
+    conn = _make_conn(execute_raises=psycopg.OperationalError("conn lost"))
+    db = _open_db(conn)
+    with pytest.raises(DatabaseError, match="tenant lookup failed"):
+        db.get_schema_name(1)
+
+
+# ---------------------------------------------------------------------------
+# has_permission
+# ---------------------------------------------------------------------------
+
+
+def test_has_permission_returns_true_when_granted() -> None:
+    conn = _make_conn(fetchone_returns=[{"1": 1}])
+    db = _open_db(conn)
+    assert db.has_permission("sub-1", 1, "action:execute") is True
+
+
+def test_has_permission_returns_false_when_no_row() -> None:
+    conn = _make_conn(fetchone_returns=[None])
+    db = _open_db(conn)
+    assert db.has_permission("sub-1", 1, "action:execute") is False
+
+
+def test_has_permission_query_error_raises_database_error() -> None:
+    import psycopg
+
+    conn = _make_conn(execute_raises=psycopg.OperationalError("db down"))
+    db = _open_db(conn)
+    with pytest.raises(DatabaseError, match="permission check failed"):
+        db.has_permission("sub-1", 1, "action:execute")
+
+
+# ---------------------------------------------------------------------------
+# load_action
+# ---------------------------------------------------------------------------
+
+
+def test_load_action_returns_row_when_found() -> None:
+    row = {"id": ACTION_ID, "from_state_id": 4, "name": "Lock"}
+    conn = _make_conn(fetchone_returns=[row])
+    db = _open_db(conn)
+    result = db.load_action(ACTION_ID, SCHEMA)
+    assert result == row
+
+
+def test_load_action_returns_none_when_missing() -> None:
+    conn = _make_conn(fetchone_returns=[None])
+    db = _open_db(conn)
+    assert db.load_action(ACTION_ID, SCHEMA) is None
+
+
+def test_load_action_query_error_raises_database_error() -> None:
+    import psycopg
+
+    conn = _make_conn(execute_raises=psycopg.OperationalError("db error"))
+    db = _open_db(conn)
+    with pytest.raises(DatabaseError, match="load_action query failed"):
+        db.load_action(ACTION_ID, SCHEMA)
+
+
+def test_load_action_invalid_schema_raises() -> None:
+    conn = _make_conn()
+    db = _open_db(conn)
+    with pytest.raises(DatabaseError, match="invalid schema_name"):
+        db.load_action(ACTION_ID, "1bad")
+
+
+# ---------------------------------------------------------------------------
+# load_message_template
+# ---------------------------------------------------------------------------
+
+
+def test_load_message_template_returns_row_when_found() -> None:
+    row = {"id": TEMPLATE_ID, "content": "hello", "is_active": True}
+    conn = _make_conn(fetchone_returns=[row])
+    db = _open_db(conn)
+    result = db.load_message_template(TEMPLATE_ID, SCHEMA)
+    assert result == row
+
+
+def test_load_message_template_returns_none_when_missing() -> None:
+    conn = _make_conn(fetchone_returns=[None])
+    db = _open_db(conn)
+    assert db.load_message_template(TEMPLATE_ID, SCHEMA) is None
+
+
+def test_load_message_template_query_error_raises() -> None:
+    import psycopg
+
+    conn = _make_conn(execute_raises=psycopg.OperationalError("db error"))
+    db = _open_db(conn)
+    with pytest.raises(DatabaseError, match="load_message_template query failed"):
+        db.load_message_template(TEMPLATE_ID, SCHEMA)
+
+
+# ---------------------------------------------------------------------------
+# validate_devices_for_action
+# ---------------------------------------------------------------------------
+
+
+def test_validate_devices_all_valid() -> None:
+    rows = [{"id": DEVICE_ID, "state_id": 4, "assigned_action_id": None, "from_state_id": 4}]
+    conn = _make_conn(fetchall_returns=[rows])
+    db = _open_db(conn)
+    valid, invalid = db.validate_devices_for_action([DEVICE_ID], ACTION_ID, SCHEMA)
+    assert len(valid) == 1
+    assert valid[0].device_id == DEVICE_ID
+    assert invalid == []
+
+
+def test_validate_devices_fsm_mismatch() -> None:
+    rows = [{"id": DEVICE_ID, "state_id": 1, "assigned_action_id": None, "from_state_id": 4}]
+    conn = _make_conn(fetchall_returns=[rows])
+    db = _open_db(conn)
+    valid, invalid = db.validate_devices_for_action([DEVICE_ID], ACTION_ID, SCHEMA)
+    assert valid == []
+    assert len(invalid) == 1
+    assert "INVALID_TRANSITION" in invalid[0].reason
+
+
+def test_validate_devices_not_found() -> None:
+    """Device ID not returned by query → DEVICE_NOT_FOUND invalid entry."""
+    missing_id = str(uuid.uuid4())
+    conn = _make_conn(fetchall_returns=[[]])  # no rows returned
+    db = _open_db(conn)
+    valid, invalid = db.validate_devices_for_action([missing_id], ACTION_ID, SCHEMA)
+    assert valid == []
+    assert len(invalid) == 1
+    assert "DEVICE_NOT_FOUND" in invalid[0].reason
+    assert invalid[0].device_id == missing_id
+
+
+def test_validate_devices_mixed() -> None:
+    """One valid, one FSM-invalid, one not-found."""
+    dev2 = str(uuid.uuid4())
+    dev3 = str(uuid.uuid4())  # not returned = not found
+    rows = [
+        {"id": DEVICE_ID, "state_id": 4, "assigned_action_id": None, "from_state_id": 4},
+        {"id": dev2, "state_id": 1, "assigned_action_id": None, "from_state_id": 4},
+    ]
+    conn = _make_conn(fetchall_returns=[rows])
+    db = _open_db(conn)
+    valid, invalid = db.validate_devices_for_action([DEVICE_ID, dev2, dev3], ACTION_ID, SCHEMA)
+    assert len(valid) == 1
+    assert valid[0].device_id == DEVICE_ID
+    assert len(invalid) == 2
+    reasons = {inv.device_id: inv.reason for inv in invalid}
+    assert "INVALID_TRANSITION" in reasons[dev2]
+    assert "DEVICE_NOT_FOUND" in reasons[dev3]
+
+
+def test_validate_devices_null_from_state_means_any_state_valid() -> None:
+    """Actions with from_state_id=NULL (e.g., Upload) accept any device state."""
+    rows = [{"id": DEVICE_ID, "state_id": 3, "assigned_action_id": None, "from_state_id": None}]
+    conn = _make_conn(fetchall_returns=[rows])
+    db = _open_db(conn)
+    valid, invalid = db.validate_devices_for_action([DEVICE_ID], ACTION_ID, SCHEMA)
+    assert len(valid) == 1
+    assert invalid == []
+
+
+def test_validate_devices_query_error_raises() -> None:
+    import psycopg
+
+    conn = _make_conn(execute_raises=psycopg.OperationalError("db error"))
+    db = _open_db(conn)
+    with pytest.raises(DatabaseError, match="validate_devices_for_action query failed"):
+        db.validate_devices_for_action([DEVICE_ID], ACTION_ID, SCHEMA)
+
+
+# ---------------------------------------------------------------------------
+# create_batch_with_devices
+# ---------------------------------------------------------------------------
+
+
+def test_create_batch_with_devices_empty_input_returns_empty() -> None:
+    conn = _make_conn()
+    db = _open_db(conn)
+    result = db.create_batch_with_devices(BATCH_ID, ACTION_ID, "sub-1", [], SCHEMA)
+    assert result == []
+
+
+def test_create_batch_with_devices_happy_path() -> None:
+    """All devices locked → returns ExecutionTuple list."""
+    valid = [ValidDevice(DEVICE_ID, 4)]
+
+    # Simulate transaction context manager
+    conn = MagicMock()
+    conn.__enter__ = MagicMock(return_value=conn)
+    conn.__exit__ = MagicMock(return_value=False)
+
+    # transaction() context manager
+    tx_ctx = MagicMock()
+    tx_ctx.__enter__ = MagicMock(return_value=None)
+    tx_ctx.__exit__ = MagicMock(return_value=False)
+    conn.transaction.return_value = tx_ctx
+
+    # cursor() calls return cursors with specific fetchone/fetchall results
+    # Call order: UPDATE RETURNING, INSERT batch_actions, INSERT ae RETURNING, INSERT bda
+    lock_cursor = MagicMock()
+    lock_cursor.__enter__ = MagicMock(return_value=lock_cursor)
+    lock_cursor.__exit__ = MagicMock(return_value=False)
+    lock_cursor.fetchall.return_value = [{"id": DEVICE_ID}]
+
+    ba_cursor = MagicMock()
+    ba_cursor.__enter__ = MagicMock(return_value=ba_cursor)
+    ba_cursor.__exit__ = MagicMock(return_value=False)
+
+    ae_cursor = MagicMock()
+    ae_cursor.__enter__ = MagicMock(return_value=ae_cursor)
+    ae_cursor.__exit__ = MagicMock(return_value=False)
+    ae_cursor.fetchone.return_value = {"id": EXECUTION_ID, "command_uuid": COMMAND_UUID_VAL}
+
+    bda_cursor = MagicMock()
+    bda_cursor.__enter__ = MagicMock(return_value=bda_cursor)
+    bda_cursor.__exit__ = MagicMock(return_value=False)
+
+    conn.cursor.side_effect = [lock_cursor, ba_cursor, ae_cursor, bda_cursor]
+
+    db = _open_db(conn)
+    results = db.create_batch_with_devices(BATCH_ID, ACTION_ID, "sub-1", valid, SCHEMA)
+
+    assert len(results) == 1
+    assert results[0].device_id == DEVICE_ID
+    assert results[0].execution_id == EXECUTION_ID
+    assert results[0].command_uuid == COMMAND_UUID_VAL
+
+
+def test_create_batch_with_devices_all_race_losers_returns_empty() -> None:
+    """UPDATE RETURNING no rows → all devices lost race → empty result."""
+    valid = [ValidDevice(DEVICE_ID, 4)]
+
+    conn = MagicMock()
+    tx_ctx = MagicMock()
+    tx_ctx.__enter__ = MagicMock(return_value=None)
+    tx_ctx.__exit__ = MagicMock(return_value=False)
+    conn.transaction.return_value = tx_ctx
+
+    lock_cursor = MagicMock()
+    lock_cursor.__enter__ = MagicMock(return_value=lock_cursor)
+    lock_cursor.__exit__ = MagicMock(return_value=False)
+    lock_cursor.fetchall.return_value = []  # no rows locked
+
+    conn.cursor.return_value = lock_cursor
+
+    db = _open_db(conn)
+    results = db.create_batch_with_devices(BATCH_ID, ACTION_ID, "sub-1", valid, SCHEMA)
+
+    assert results == []
+
+
+def test_create_batch_with_devices_db_error_raises() -> None:
+    """psycopg error inside transaction → DatabaseError raised."""
+    import psycopg
+
+    valid = [ValidDevice(DEVICE_ID, 4)]
+    conn = MagicMock()
+    tx_ctx = MagicMock()
+    tx_ctx.__enter__ = MagicMock(side_effect=psycopg.OperationalError("connection reset"))
+    tx_ctx.__exit__ = MagicMock(return_value=False)
+    conn.transaction.return_value = tx_ctx
+
+    db = _open_db(conn)
+    with pytest.raises(DatabaseError, match="create_batch_with_devices transaction failed"):
+        db.create_batch_with_devices(BATCH_ID, ACTION_ID, "sub-1", valid, SCHEMA)
+
+
+# ---------------------------------------------------------------------------
+# _require_conn
+# ---------------------------------------------------------------------------
+
+
+def test_require_conn_outside_context_manager_raises() -> None:
+    db = Database()
+    with pytest.raises(DatabaseError, match="outside context manager"):
+        db._require_conn()  # noqa: SLF001
+
+
+# ---------------------------------------------------------------------------
+# Database context manager
+# ---------------------------------------------------------------------------
+
+
+def test_database_connect_failure_raises_database_error() -> None:
+    """psycopg.connect failing → DatabaseError on __enter__."""
+    import psycopg
+
+    with patch("db.psycopg.connect", side_effect=psycopg.OperationalError("unreachable")):
+        with pytest.raises(DatabaseError, match="database connection failed"):
+            with Database():
+                pass
+
+
+# ---------------------------------------------------------------------------
+# get_action_log_by_batch_id (P1b)
+# ---------------------------------------------------------------------------
+
+_BATCH_ID = str(uuid.uuid4())
+_ACTION_ID_2 = str(uuid.uuid4())
+_CREATED_AT = datetime(2026, 4, 26, 10, 0, 0, tzinfo=UTC)
+
+
+def _make_action_log_row(
+    batch_id: str = _BATCH_ID,
+    error_count: int = 0,
+) -> dict[str, Any]:
+    return {
+        "id": str(uuid.uuid4()),
+        "batch_id": batch_id,
+        "action_id": _ACTION_ID_2,
+        "created_by": "sub-abc",
+        "total_devices": 5,
+        "status": "IN_PROGRESS",
+        "created_at": _CREATED_AT,
+        "error_count": error_count,
+    }
+
+
+def test_get_action_log_by_batch_id_returns_row() -> None:
+    row = _make_action_log_row(error_count=2)
+    conn = _make_conn(fetchone_returns=[row])
+    db = _open_db(conn)
+    result = db.get_action_log_by_batch_id(_BATCH_ID, SCHEMA)
+    assert result is not None
+    assert result["batch_id"] == _BATCH_ID
+    assert result["error_count"] == 2
+
+
+def test_get_action_log_by_batch_id_returns_none_when_missing() -> None:
+    conn = _make_conn(fetchone_returns=[None])
+    db = _open_db(conn)
+    result = db.get_action_log_by_batch_id(_BATCH_ID, SCHEMA)
+    assert result is None
+
+
+def test_get_action_log_by_batch_id_query_error_raises() -> None:
+    import psycopg
+
+    conn = _make_conn(execute_raises=psycopg.OperationalError("db error"))
+    db = _open_db(conn)
+    with pytest.raises(DatabaseError, match="get_action_log_by_batch_id query failed"):
+        db.get_action_log_by_batch_id(_BATCH_ID, SCHEMA)
+
+
+def test_get_action_log_by_batch_id_invalid_schema_raises() -> None:
+    conn = _make_conn()
+    db = _open_db(conn)
+    with pytest.raises(DatabaseError, match="invalid schema_name"):
+        db.get_action_log_by_batch_id(_BATCH_ID, "1BAD")
+
+
+# ---------------------------------------------------------------------------
+# list_action_logs (P1b)
+# ---------------------------------------------------------------------------
+
+
+def _make_list_rows(n: int) -> list[dict[str, Any]]:
+    return [_make_action_log_row(batch_id=str(uuid.uuid4())) for _ in range(n)]
+
+
+def test_list_action_logs_first_page_no_cursor() -> None:
+    rows = _make_list_rows(3)
+    conn = _make_conn(fetchall_returns=[rows])
+    db = _open_db(conn)
+    result, next_cursor = db.list_action_logs(limit=20, after_cursor=None, schema=SCHEMA)
+    assert len(result) == 3
+    assert next_cursor is None
+
+
+def test_list_action_logs_returns_next_cursor_when_more_pages() -> None:
+    # Return limit+1 rows to signal more pages exist.
+    rows = _make_list_rows(6)
+    conn = _make_conn(fetchall_returns=[rows])
+    db = _open_db(conn)
+    result, next_cursor = db.list_action_logs(limit=5, after_cursor=None, schema=SCHEMA)
+    assert len(result) == 5  # only limit rows returned
+    assert next_cursor is not None  # cursor set from last kept row
+
+
+def test_list_action_logs_with_valid_cursor() -> None:
+    ts = datetime(2026, 4, 26, 9, 0, 0, tzinfo=UTC)
+    cursor = _encode_action_log_cursor(ts, str(uuid.uuid4()))
+    rows = _make_list_rows(2)
+    conn = _make_conn(fetchall_returns=[rows])
+    db = _open_db(conn)
+    result, next_cursor = db.list_action_logs(limit=20, after_cursor=cursor, schema=SCHEMA)
+    assert len(result) == 2
+    assert next_cursor is None
+
+
+def test_list_action_logs_empty_result() -> None:
+    conn = _make_conn(fetchall_returns=[[]])
+    db = _open_db(conn)
+    result, next_cursor = db.list_action_logs(limit=20, after_cursor=None, schema=SCHEMA)
+    assert result == []
+    assert next_cursor is None
+
+
+def test_list_action_logs_invalid_cursor_raises() -> None:
+    conn = _make_conn(fetchall_returns=[[]])
+    db = _open_db(conn)
+    with pytest.raises(InvalidInputError):
+        db.list_action_logs(limit=10, after_cursor="!!!not-base64!!!", schema=SCHEMA)
+
+
+def test_list_action_logs_query_error_raises() -> None:
+    import psycopg
+
+    conn = _make_conn(execute_raises=psycopg.OperationalError("db error"))
+    db = _open_db(conn)
+    with pytest.raises(DatabaseError, match="list_action_logs query failed"):
+        db.list_action_logs(limit=10, after_cursor=None, schema=SCHEMA)
+
+
+# ---------------------------------------------------------------------------
+# get_failed_devices_for_batch (P1b)
+# ---------------------------------------------------------------------------
+
+
+def test_get_failed_devices_returns_rows() -> None:
+    rows = [
+        {
+            "device_id": DEVICE_ID,
+            "error_code": "TIMEOUT",
+            "error_message": "timed out",
+            "finished_at": _CREATED_AT,
+        }
+    ]
+    conn = _make_conn(fetchall_returns=[rows])
+    db = _open_db(conn)
+    result = db.get_failed_devices_for_batch(_BATCH_ID, SCHEMA)
+    assert len(result) == 1
+    assert result[0]["error_code"] == "TIMEOUT"
+
+
+def test_get_failed_devices_returns_empty_list_when_no_failures() -> None:
+    conn = _make_conn(fetchall_returns=[[]])
+    db = _open_db(conn)
+    result = db.get_failed_devices_for_batch(_BATCH_ID, SCHEMA)
+    assert result == []
+
+
+def test_get_failed_devices_query_error_raises() -> None:
+    import psycopg
+
+    conn = _make_conn(execute_raises=psycopg.OperationalError("db error"))
+    db = _open_db(conn)
+    with pytest.raises(DatabaseError, match="get_failed_devices_for_batch query failed"):
+        db.get_failed_devices_for_batch(_BATCH_ID, SCHEMA)
+
+
+# ---------------------------------------------------------------------------
+# Cursor helpers (P1b)
+# ---------------------------------------------------------------------------
+
+
+def test_cursor_encode_decode_round_trip() -> None:
+    ts = datetime(2026, 4, 26, 12, 0, 0, tzinfo=UTC)
+    id_ = str(uuid.uuid4())
+    token = _encode_action_log_cursor(ts, id_)
+    decoded_ts, decoded_id = _decode_action_log_cursor(token)
+    assert decoded_ts == ts
+    assert str(decoded_id) == id_
+
+
+def test_cursor_decode_invalid_base64_raises() -> None:
+    with pytest.raises(InvalidInputError, match="base64 decode failed"):
+        _decode_action_log_cursor("@@@not_base64@@@")
+
+
+def test_cursor_decode_missing_separator_raises() -> None:
+    import base64
+
+    bad = base64.urlsafe_b64encode(b"nodividerhere").decode()
+    with pytest.raises(InvalidInputError, match="missing separator"):
+        _decode_action_log_cursor(bad)
+
+
+def test_cursor_decode_bad_datetime_raises() -> None:
+    import base64
+
+    bad = base64.urlsafe_b64encode(b"not-a-date|" + str(uuid.uuid4()).encode()).decode()
+    with pytest.raises(InvalidInputError, match="bad datetime"):
+        _decode_action_log_cursor(bad)
+
+
+def test_cursor_decode_bad_uuid_raises() -> None:
+    import base64
+
+    ts = datetime(2026, 4, 26, 12, 0, 0, tzinfo=UTC).isoformat()
+    bad = base64.urlsafe_b64encode(f"{ts}|not-a-uuid".encode()).decode()
+    with pytest.raises(InvalidInputError, match="bad UUID"):
+        _decode_action_log_cursor(bad)
+
+
+def test_cursor_naive_datetime_gets_utc_tzinfo() -> None:
+    """Naive datetimes decoded from cursor should become UTC-aware."""
+    import base64
+
+    ts = datetime(2026, 4, 26, 12, 0, 0)  # no tzinfo
+    id_ = str(uuid.uuid4())
+    raw = f"{ts.isoformat()}|{id_}"
+    token = base64.urlsafe_b64encode(raw.encode()).decode()
+    decoded_ts, _ = _decode_action_log_cursor(token)
+    assert decoded_ts.tzinfo is not None

--- a/fluxion-backend/modules/action_resolver/tests/test_handler.py
+++ b/fluxion-backend/modules/action_resolver/tests/test_handler.py
@@ -1,0 +1,837 @@
+"""Tests for action_resolver handler.py.
+
+Uses unittest.mock to stub DB and SQS calls — no real infrastructure needed.
+Covers:
+  - Happy path: assignAction + assignBulkAction
+  - Missing action → ActionNotFoundError (whole-request)
+  - Archived template → TemplateArchivedError (whole-request)
+  - Template not found → TemplateNotFoundError (whole-request)
+  - FSM mismatch → INVALID_TRANSITION (per-device for single / in failed[] for bulk)
+  - Already-assigned device → DEVICE_BUSY (race-safe path)
+  - SQS enqueue failure after DB commit → request still succeeds
+  - Permission denied
+  - Unknown field → UNKNOWN_FIELD error dict
+  - getActionLog: found, not found (null), permission denied
+  - listActionLogs: happy path, cursor pagination
+  - generateActionLogErrorReport: happy path, empty errors, batch not found
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from handler import lambda_handler
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+DEVICE_ID = str(uuid.uuid4())
+ACTION_ID = str(uuid.uuid4())
+TEMPLATE_ID = str(uuid.uuid4())
+EXECUTION_ID = str(uuid.uuid4())
+COMMAND_UUID = str(uuid.uuid4())
+BATCH_ID = str(uuid.uuid4())
+
+
+def _make_event(
+    field: str,
+    input_args: dict[str, Any] | None = None,
+    cognito_sub: str = "sub-test",
+    tenant_id: str = "1",
+) -> dict[str, Any]:
+    return {
+        "info": {"fieldName": field},
+        "arguments": {"input": input_args or {}},
+        "identity": {"claims": {"sub": cognito_sub, "custom:tenant_id": tenant_id}},
+    }
+
+
+def _make_ctx_mock() -> MagicMock:
+    return MagicMock(aws_request_id="test-corr-id")
+
+
+def _make_auth_db(has_perm: bool = True) -> MagicMock:
+    """Auth-phase DB mock (get_schema_name + has_permission)."""
+    mock_db = MagicMock()
+    mock_db.__enter__ = MagicMock(return_value=mock_db)
+    mock_db.__exit__ = MagicMock(return_value=False)
+    mock_db.get_schema_name.return_value = "dev1"
+    mock_db.has_permission.return_value = has_perm
+    return mock_db
+
+
+_SENTINEL: dict[
+    str, Any
+] = {}  # unique sentinel: distinguishes "caller passed None" from "not passed"
+
+
+def _make_repo_db(
+    action_row: dict[str, Any] | None = _SENTINEL,  # type: ignore[assignment]
+    template_row: dict[str, Any] | None = None,
+    valid_devices: list[Any] | None = None,
+    invalid_devices: list[Any] | None = None,
+    executions: list[Any] | None = None,
+) -> MagicMock:
+    """Repo-phase DB mock (load_action, load_message_template, validate_devices, create_batch).
+
+    Pass action_row=None explicitly to simulate a missing action (load_action returns None).
+    Omitting action_row uses a default valid action row.
+    """
+    from db import ExecutionTuple, ValidDevice
+
+    mock_db = MagicMock()
+    mock_db.__enter__ = MagicMock(return_value=mock_db)
+    mock_db.__exit__ = MagicMock(return_value=False)
+    mock_db.load_action.return_value = (
+        {"id": ACTION_ID, "from_state_id": 4, "name": "Lock"}
+        if action_row is _SENTINEL
+        else action_row
+    )
+    mock_db.load_message_template.return_value = template_row
+    mock_db.validate_devices_for_action.return_value = (
+        valid_devices if valid_devices is not None else [ValidDevice(DEVICE_ID, 4)],
+        invalid_devices if invalid_devices is not None else [],
+    )
+    mock_db.create_batch_with_devices.return_value = (
+        executions
+        if executions is not None
+        else [ExecutionTuple(DEVICE_ID, EXECUTION_ID, COMMAND_UUID)]
+    )
+    return mock_db
+
+
+# ---------------------------------------------------------------------------
+# assignAction — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_assign_action_happy_path() -> None:
+    """assignAction happy path returns AssignActionResponse dict."""
+    auth_db = _make_auth_db()
+    repo_db = _make_repo_db()
+
+    def db_factory(*_args: Any, **_kwargs: Any) -> MagicMock:
+        # auth.py opens Database twice (get_schema_name + has_permission),
+        # handler opens it once for repo; use a side_effect cycle
+        return auth_db
+
+    with (
+        patch("auth.Database", return_value=auth_db),
+        patch("auth._resolve_user_id", return_value=1),
+        patch("handler.Database", return_value=repo_db),
+        patch("handler.enqueue_action_trigger", return_value="msg-id-1"),
+    ):
+        result = lambda_handler(
+            _make_event("assignAction", {"deviceId": DEVICE_ID, "actionId": ACTION_ID}),
+            _make_ctx_mock(),
+        )
+
+    assert result["executionId"] == EXECUTION_ID
+    assert result["commandUuid"] == COMMAND_UUID
+    assert result["status"] == "ACTION_PENDING"
+
+
+def test_assign_action_with_template_happy_path() -> None:
+    """assignAction with messageTemplateId passes messageContent to SQS envelope."""
+    auth_db = _make_auth_db()
+    repo_db = _make_repo_db(
+        template_row={"id": TEMPLATE_ID, "content": "Lock your device", "is_active": True}
+    )
+
+    captured_envelopes: list[dict[str, Any]] = []
+
+    def capture_enqueue(body: dict[str, Any], **_kw: Any) -> str:
+        captured_envelopes.append(body)
+        return "msg-id"
+
+    with (
+        patch("auth.Database", return_value=auth_db),
+        patch("auth._resolve_user_id", return_value=1),
+        patch("handler.Database", return_value=repo_db),
+        patch("handler.enqueue_action_trigger", side_effect=capture_enqueue),
+    ):
+        result = lambda_handler(
+            _make_event(
+                "assignAction",
+                {"deviceId": DEVICE_ID, "actionId": ACTION_ID, "messageTemplateId": TEMPLATE_ID},
+            ),
+            _make_ctx_mock(),
+        )
+
+    assert "errorType" not in result
+    assert len(captured_envelopes) == 1
+    assert captured_envelopes[0]["messageContent"] == "Lock your device"
+
+
+# ---------------------------------------------------------------------------
+# assignAction — error cases
+# ---------------------------------------------------------------------------
+
+
+def test_assign_action_missing_action_returns_error() -> None:
+    """assignAction with unknown actionId → ACTION_NOT_FOUND error."""
+    auth_db = _make_auth_db()
+    repo_db = _make_repo_db(action_row=None)
+
+    with (
+        patch("auth.Database", return_value=auth_db),
+        patch("auth._resolve_user_id", return_value=1),
+        patch("handler.Database", return_value=repo_db),
+    ):
+        result = lambda_handler(
+            _make_event("assignAction", {"deviceId": DEVICE_ID, "actionId": ACTION_ID}),
+            _make_ctx_mock(),
+        )
+
+    assert result["errorType"] == "ACTION_NOT_FOUND"
+
+
+def test_assign_action_template_not_found_returns_error() -> None:
+    """assignAction with unknown templateId → TEMPLATE_NOT_FOUND."""
+    auth_db = _make_auth_db()
+    repo_db = _make_repo_db(template_row=None)
+    # Override load_message_template to simulate missing template
+    repo_db.load_message_template.return_value = None
+
+    with (
+        patch("auth.Database", return_value=auth_db),
+        patch("auth._resolve_user_id", return_value=1),
+        patch("handler.Database", return_value=repo_db),
+    ):
+        result = lambda_handler(
+            _make_event(
+                "assignAction",
+                {
+                    "deviceId": DEVICE_ID,
+                    "actionId": ACTION_ID,
+                    "messageTemplateId": TEMPLATE_ID,
+                },
+            ),
+            _make_ctx_mock(),
+        )
+
+    assert result["errorType"] == "TEMPLATE_NOT_FOUND"
+
+
+def test_assign_action_template_archived_returns_error() -> None:
+    """assignAction with archived template → TEMPLATE_ARCHIVED."""
+    auth_db = _make_auth_db()
+    repo_db = _make_repo_db(template_row={"id": TEMPLATE_ID, "content": "old", "is_active": False})
+
+    with (
+        patch("auth.Database", return_value=auth_db),
+        patch("auth._resolve_user_id", return_value=1),
+        patch("handler.Database", return_value=repo_db),
+    ):
+        result = lambda_handler(
+            _make_event(
+                "assignAction",
+                {
+                    "deviceId": DEVICE_ID,
+                    "actionId": ACTION_ID,
+                    "messageTemplateId": TEMPLATE_ID,
+                },
+            ),
+            _make_ctx_mock(),
+        )
+
+    assert result["errorType"] == "TEMPLATE_ARCHIVED"
+
+
+def test_assign_action_fsm_mismatch_returns_invalid_transition() -> None:
+    """assignAction where device state ≠ action.from_state → INVALID_TRANSITION."""
+    from db import InvalidDevice
+
+    auth_db = _make_auth_db()
+    repo_db = _make_repo_db(
+        valid_devices=[],
+        invalid_devices=[
+            InvalidDevice(
+                DEVICE_ID,
+                "INVALID_TRANSITION: device state 1 does not match action from_state 4",
+            )
+        ],
+    )
+
+    with (
+        patch("auth.Database", return_value=auth_db),
+        patch("auth._resolve_user_id", return_value=1),
+        patch("handler.Database", return_value=repo_db),
+    ):
+        result = lambda_handler(
+            _make_event("assignAction", {"deviceId": DEVICE_ID, "actionId": ACTION_ID}),
+            _make_ctx_mock(),
+        )
+
+    assert result["errorType"] == "INVALID_TRANSITION"
+
+
+def test_assign_action_device_not_found_returns_not_found() -> None:
+    """assignAction where device UUID not in tenant → NOT_FOUND."""
+    from db import InvalidDevice
+
+    auth_db = _make_auth_db()
+    repo_db = _make_repo_db(
+        valid_devices=[],
+        invalid_devices=[
+            InvalidDevice(DEVICE_ID, f"DEVICE_NOT_FOUND: device {DEVICE_ID} not found")
+        ],
+    )
+
+    with (
+        patch("auth.Database", return_value=auth_db),
+        patch("auth._resolve_user_id", return_value=1),
+        patch("handler.Database", return_value=repo_db),
+    ):
+        result = lambda_handler(
+            _make_event("assignAction", {"deviceId": DEVICE_ID, "actionId": ACTION_ID}),
+            _make_ctx_mock(),
+        )
+
+    assert result["errorType"] == "NOT_FOUND"
+
+
+def test_assign_action_device_busy_returns_device_busy() -> None:
+    """assignAction where device lost race → DEVICE_BUSY."""
+    from db import ValidDevice
+
+    auth_db = _make_auth_db()
+    # Device passes FSM but is absent from execution results (lost race).
+    repo_db = _make_repo_db(
+        valid_devices=[ValidDevice(DEVICE_ID, 4)],
+        invalid_devices=[],
+        executions=[],  # race loser: locked none
+    )
+
+    with (
+        patch("auth.Database", return_value=auth_db),
+        patch("auth._resolve_user_id", return_value=1),
+        patch("handler.Database", return_value=repo_db),
+    ):
+        result = lambda_handler(
+            _make_event("assignAction", {"deviceId": DEVICE_ID, "actionId": ACTION_ID}),
+            _make_ctx_mock(),
+        )
+
+    assert result["errorType"] == "DEVICE_BUSY"
+
+
+def test_assign_action_sqs_failure_after_commit_still_succeeds() -> None:
+    """SQS failure post-commit does NOT fail the user request."""
+    from sqs import SqsError
+
+    auth_db = _make_auth_db()
+    repo_db = _make_repo_db()
+
+    with (
+        patch("auth.Database", return_value=auth_db),
+        patch("auth._resolve_user_id", return_value=1),
+        patch("handler.Database", return_value=repo_db),
+        patch("handler.enqueue_action_trigger", side_effect=SqsError("queue unavailable")),
+    ):
+        result = lambda_handler(
+            _make_event("assignAction", {"deviceId": DEVICE_ID, "actionId": ACTION_ID}),
+            _make_ctx_mock(),
+        )
+
+    # Request succeeds even though SQS failed.
+    assert "errorType" not in result
+    assert result["executionId"] == EXECUTION_ID
+
+
+def test_assign_action_permission_denied() -> None:
+    """Missing permission → FORBIDDEN error dict."""
+    auth_db = _make_auth_db(has_perm=False)
+
+    with (
+        patch("auth.Database", return_value=auth_db),
+        patch("auth._resolve_user_id", return_value=1),
+    ):
+        result = lambda_handler(
+            _make_event("assignAction", {"deviceId": DEVICE_ID, "actionId": ACTION_ID}),
+            _make_ctx_mock(),
+        )
+
+    assert result["errorType"] == "FORBIDDEN"
+
+
+# ---------------------------------------------------------------------------
+# assignBulkAction — happy + partial-failure
+# ---------------------------------------------------------------------------
+
+
+def test_assign_bulk_action_all_valid() -> None:
+    """assignBulkAction with all devices valid returns populated valid[] and empty failed[]."""
+    dev2 = str(uuid.uuid4())
+    exec2 = str(uuid.uuid4())
+    cmd2 = str(uuid.uuid4())
+    from db import ExecutionTuple, ValidDevice
+
+    auth_db = _make_auth_db()
+    repo_db = _make_repo_db(
+        valid_devices=[ValidDevice(DEVICE_ID, 4), ValidDevice(dev2, 4)],
+        invalid_devices=[],
+        executions=[
+            ExecutionTuple(DEVICE_ID, EXECUTION_ID, COMMAND_UUID),
+            ExecutionTuple(dev2, exec2, cmd2),
+        ],
+    )
+
+    with (
+        patch("auth.Database", return_value=auth_db),
+        patch("auth._resolve_user_id", return_value=1),
+        patch("handler.Database", return_value=repo_db),
+        patch("handler.enqueue_action_trigger", return_value="msg-id"),
+    ):
+        result = lambda_handler(
+            _make_event(
+                "assignBulkAction",
+                {"deviceIds": [DEVICE_ID, dev2], "actionId": ACTION_ID},
+            ),
+            _make_ctx_mock(),
+        )
+
+    assert len(result["valid"]) == 2
+    assert result["failed"] == []
+    assert result["valid"][0]["status"] == "ACTION_PENDING"
+
+
+def test_assign_bulk_action_partial_failure() -> None:
+    """assignBulkAction with one FSM-invalid device → 1 valid + 1 failed."""
+    from db import ExecutionTuple, InvalidDevice, ValidDevice
+
+    bad_device = str(uuid.uuid4())
+    auth_db = _make_auth_db()
+    repo_db = _make_repo_db(
+        valid_devices=[ValidDevice(DEVICE_ID, 4)],
+        invalid_devices=[
+            InvalidDevice(
+                bad_device, "INVALID_TRANSITION: device state 1 does not match action from_state 4"
+            )
+        ],
+        executions=[ExecutionTuple(DEVICE_ID, EXECUTION_ID, COMMAND_UUID)],
+    )
+
+    with (
+        patch("auth.Database", return_value=auth_db),
+        patch("auth._resolve_user_id", return_value=1),
+        patch("handler.Database", return_value=repo_db),
+        patch("handler.enqueue_action_trigger", return_value="msg-id"),
+    ):
+        result = lambda_handler(
+            _make_event(
+                "assignBulkAction",
+                {"deviceIds": [DEVICE_ID, bad_device], "actionId": ACTION_ID},
+            ),
+            _make_ctx_mock(),
+        )
+
+    assert len(result["valid"]) == 1
+    assert len(result["failed"]) == 1
+    assert result["failed"][0]["deviceId"] == bad_device
+    assert "INVALID_TRANSITION" in result["failed"][0]["reason"]
+
+
+def test_assign_bulk_action_race_loser_in_failed() -> None:
+    """Device that passes FSM but loses the UPDATE race ends up in failed[]."""
+    from db import ExecutionTuple, ValidDevice
+
+    dev2 = str(uuid.uuid4())
+    auth_db = _make_auth_db()
+    repo_db = _make_repo_db(
+        valid_devices=[ValidDevice(DEVICE_ID, 4), ValidDevice(dev2, 4)],
+        invalid_devices=[],
+        # Only DEVICE_ID was locked; dev2 lost the race.
+        executions=[ExecutionTuple(DEVICE_ID, EXECUTION_ID, COMMAND_UUID)],
+    )
+
+    with (
+        patch("auth.Database", return_value=auth_db),
+        patch("auth._resolve_user_id", return_value=1),
+        patch("handler.Database", return_value=repo_db),
+        patch("handler.enqueue_action_trigger", return_value="msg-id"),
+    ):
+        result = lambda_handler(
+            _make_event(
+                "assignBulkAction",
+                {"deviceIds": [DEVICE_ID, dev2], "actionId": ACTION_ID},
+            ),
+            _make_ctx_mock(),
+        )
+
+    assert len(result["valid"]) == 1
+    assert len(result["failed"]) == 1
+    assert result["failed"][0]["deviceId"] == dev2
+    assert "DEVICE_BUSY" in result["failed"][0]["reason"]
+
+
+def test_assign_bulk_action_missing_action_returns_error() -> None:
+    """assignBulkAction with unknown actionId → ACTION_NOT_FOUND (whole-request)."""
+    auth_db = _make_auth_db()
+    repo_db = _make_repo_db(action_row=None)
+
+    with (
+        patch("auth.Database", return_value=auth_db),
+        patch("auth._resolve_user_id", return_value=1),
+        patch("handler.Database", return_value=repo_db),
+    ):
+        result = lambda_handler(
+            _make_event(
+                "assignBulkAction",
+                {"deviceIds": [DEVICE_ID], "actionId": ACTION_ID},
+            ),
+            _make_ctx_mock(),
+        )
+
+    assert result["errorType"] == "ACTION_NOT_FOUND"
+
+
+# ---------------------------------------------------------------------------
+# Dispatch / misc
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_field_returns_appsync_error() -> None:
+    """Unknown field → UNKNOWN_FIELD error dict."""
+    result = lambda_handler(
+        {"info": {"fieldName": "noSuchField"}, "arguments": {}},
+        _make_ctx_mock(),
+    )
+    assert result["errorType"] == "UNKNOWN_FIELD"
+
+
+def test_missing_field_name_returns_error() -> None:
+    """No info.fieldName → UNKNOWN_FIELD."""
+    result = lambda_handler({}, _make_ctx_mock())
+    assert result["errorType"] == "UNKNOWN_FIELD"
+
+
+def test_invalid_input_returns_invalid_input_error() -> None:
+    """Empty deviceIds → INVALID_INPUT from Pydantic validator."""
+    auth_db = _make_auth_db()
+
+    with (
+        patch("auth.Database", return_value=auth_db),
+        patch("auth._resolve_user_id", return_value=1),
+    ):
+        result = lambda_handler(
+            _make_event("assignBulkAction", {"deviceIds": [], "actionId": ACTION_ID}),
+            _make_ctx_mock(),
+        )
+
+    assert result["errorType"] == "INVALID_INPUT"
+
+
+# ---------------------------------------------------------------------------
+# Helpers for P1b tests
+# ---------------------------------------------------------------------------
+
+from datetime import UTC, datetime  # noqa: E402
+
+
+def _make_direct_event(
+    field: str,
+    args: dict[str, Any],
+    cognito_sub: str = "sub-test",
+    tenant_id: str = "1",
+) -> dict[str, Any]:
+    """Event where arguments are direct (no 'input' wrapper) — for query fields."""
+    return {
+        "info": {"fieldName": field},
+        "arguments": args,
+        "identity": {"claims": {"sub": cognito_sub, "custom:tenant_id": tenant_id}},
+    }
+
+
+def _make_actionlog_row(batch_id: str = BATCH_ID) -> dict[str, Any]:
+    return {
+        "id": str(uuid.uuid4()),
+        "batch_id": batch_id,
+        "action_id": ACTION_ID,
+        "created_by": "sub-test",
+        "total_devices": 3,
+        "status": "IN_PROGRESS",
+        "created_at": datetime(2026, 4, 26, 10, 0, 0, tzinfo=UTC),
+        "error_count": 1,
+    }
+
+
+def _make_actionlog_read_db(
+    actionlog_row: dict[str, Any] | None = None,
+    list_rows: list[dict[str, Any]] | None = None,
+    next_cursor: str | None = None,
+    failed_rows: list[dict[str, Any]] | None = None,
+) -> MagicMock:
+    """DB mock for ActionLog read methods."""
+    mock_db = MagicMock()
+    mock_db.__enter__ = MagicMock(return_value=mock_db)
+    mock_db.__exit__ = MagicMock(return_value=False)
+    mock_db.get_action_log_by_batch_id.return_value = actionlog_row
+    mock_db.list_action_logs.return_value = (list_rows or [], next_cursor)
+    mock_db.get_failed_devices_for_batch.return_value = failed_rows or []
+    return mock_db
+
+
+def _make_actionlog_auth_db(has_perm: bool = True) -> MagicMock:
+    """Auth-phase DB mock configured for actionlog:read permission."""
+    mock_db = MagicMock()
+    mock_db.__enter__ = MagicMock(return_value=mock_db)
+    mock_db.__exit__ = MagicMock(return_value=False)
+    mock_db.get_schema_name.return_value = "dev1"
+    mock_db.has_permission.return_value = has_perm
+    return mock_db
+
+
+# ---------------------------------------------------------------------------
+# getActionLog
+# ---------------------------------------------------------------------------
+
+
+def test_get_action_log_returns_row() -> None:
+    """getActionLog happy path returns ActionLog dict."""
+    auth_db = _make_actionlog_auth_db()
+    repo_db = _make_actionlog_read_db(actionlog_row=_make_actionlog_row())
+
+    with (
+        patch("auth.Database", return_value=auth_db),
+        patch("auth._resolve_user_id", return_value=1),
+        patch("handler.Database", return_value=repo_db),
+    ):
+        result = lambda_handler(
+            _make_direct_event("getActionLog", {"batchId": BATCH_ID}),
+            _make_ctx_mock(),
+        )
+
+    assert result is not None
+    assert result["batchId"] == BATCH_ID
+    assert result["errorCount"] == 1
+    assert result["status"] == "IN_PROGRESS"
+    assert "created_by" in result
+    assert "created_at" in result
+
+
+def test_get_action_log_returns_none_when_not_found() -> None:
+    """getActionLog returns None (not error) when batch doesn't exist."""
+    auth_db = _make_actionlog_auth_db()
+    repo_db = _make_actionlog_read_db(actionlog_row=None)
+
+    with (
+        patch("auth.Database", return_value=auth_db),
+        patch("auth._resolve_user_id", return_value=1),
+        patch("handler.Database", return_value=repo_db),
+    ):
+        result = lambda_handler(
+            _make_direct_event("getActionLog", {"batchId": BATCH_ID}),
+            _make_ctx_mock(),
+        )
+
+    assert result is None
+
+
+def test_get_action_log_permission_denied() -> None:
+    """getActionLog without actionlog:read → FORBIDDEN."""
+    auth_db = _make_actionlog_auth_db(has_perm=False)
+
+    with (
+        patch("auth.Database", return_value=auth_db),
+        patch("auth._resolve_user_id", return_value=1),
+    ):
+        result = lambda_handler(
+            _make_direct_event("getActionLog", {"batchId": BATCH_ID}),
+            _make_ctx_mock(),
+        )
+
+    assert result["errorType"] == "FORBIDDEN"
+
+
+# ---------------------------------------------------------------------------
+# listActionLogs
+# ---------------------------------------------------------------------------
+
+
+def test_list_action_logs_returns_items_and_null_cursor() -> None:
+    """listActionLogs happy path returns items list and null nextToken."""
+    rows = [_make_actionlog_row(), _make_actionlog_row()]
+    auth_db = _make_actionlog_auth_db()
+    repo_db = _make_actionlog_read_db(list_rows=rows, next_cursor=None)
+
+    with (
+        patch("auth.Database", return_value=auth_db),
+        patch("auth._resolve_user_id", return_value=1),
+        patch("handler.Database", return_value=repo_db),
+    ):
+        result = lambda_handler(
+            _make_direct_event("listActionLogs", {"limit": 20}),
+            _make_ctx_mock(),
+        )
+
+    assert len(result["items"]) == 2
+    assert result["nextToken"] is None
+
+
+def test_list_action_logs_returns_next_token_when_more_pages() -> None:
+    """listActionLogs returns nextToken when db indicates more pages."""
+    rows = [_make_actionlog_row()]
+    cursor = "some-cursor-token"
+    auth_db = _make_actionlog_auth_db()
+    repo_db = _make_actionlog_read_db(list_rows=rows, next_cursor=cursor)
+
+    with (
+        patch("auth.Database", return_value=auth_db),
+        patch("auth._resolve_user_id", return_value=1),
+        patch("handler.Database", return_value=repo_db),
+    ):
+        result = lambda_handler(
+            _make_direct_event("listActionLogs", {"limit": 1}),
+            _make_ctx_mock(),
+        )
+
+    assert result["nextToken"] == cursor
+
+
+def test_list_action_logs_default_limit_used() -> None:
+    """listActionLogs passes limit=20 by default when not specified."""
+    auth_db = _make_actionlog_auth_db()
+    repo_db = _make_actionlog_read_db(list_rows=[])
+
+    with (
+        patch("auth.Database", return_value=auth_db),
+        patch("auth._resolve_user_id", return_value=1),
+        patch("handler.Database", return_value=repo_db),
+    ):
+        lambda_handler(
+            _make_direct_event("listActionLogs", {}),
+            _make_ctx_mock(),
+        )
+
+    repo_db.list_action_logs.assert_called_once_with(limit=20, after_cursor=None, schema="dev1")
+
+
+# ---------------------------------------------------------------------------
+# generateActionLogErrorReport
+# ---------------------------------------------------------------------------
+
+
+def test_generate_error_report_happy_path() -> None:
+    """generateActionLogErrorReport returns batchId, url, expiresAt."""
+    auth_db = _make_actionlog_auth_db()
+    repo_db = _make_actionlog_read_db(
+        actionlog_row=_make_actionlog_row(),
+        failed_rows=[
+            {
+                "device_id": DEVICE_ID,
+                "error_code": "TIMEOUT",
+                "error_message": "timed out",
+                "finished_at": "2026-04-26T10:00:00+00:00",
+            }
+        ],
+    )
+
+    with (
+        patch("auth.Database", return_value=auth_db),
+        patch("auth._resolve_user_id", return_value=1),
+        patch("handler.Database", return_value=repo_db),
+        patch("handler.put_csv"),
+        patch("handler.presigned_get_url", return_value="https://s3.example.com/signed-url"),
+    ):
+        result = lambda_handler(
+            _make_direct_event("generateActionLogErrorReport", {"batchId": BATCH_ID}),
+            _make_ctx_mock(),
+        )
+
+    assert result["batchId"] == BATCH_ID
+    assert result["url"] == "https://s3.example.com/signed-url"
+    assert "expiresAt" in result
+    # expiresAt must be ISO-8601 string with timezone offset
+    assert "+" in result["expiresAt"] or result["expiresAt"].endswith("Z")
+
+
+def test_generate_error_report_empty_failed_rows_still_returns_url() -> None:
+    """0 failed rows produces header-only CSV and returns URL (no error raised)."""
+    auth_db = _make_actionlog_auth_db()
+    repo_db = _make_actionlog_read_db(
+        actionlog_row=_make_actionlog_row(),
+        failed_rows=[],
+    )
+
+    with (
+        patch("auth.Database", return_value=auth_db),
+        patch("auth._resolve_user_id", return_value=1),
+        patch("handler.Database", return_value=repo_db),
+        patch("handler.put_csv"),
+        patch("handler.presigned_get_url", return_value="https://s3.example.com/empty-url"),
+    ):
+        result = lambda_handler(
+            _make_direct_event("generateActionLogErrorReport", {"batchId": BATCH_ID}),
+            _make_ctx_mock(),
+        )
+
+    assert "errorType" not in result
+    assert result["url"] == "https://s3.example.com/empty-url"
+
+
+def test_generate_error_report_batch_not_found_returns_error() -> None:
+    """generateActionLogErrorReport with unknown batchId → BATCH_NOT_FOUND."""
+    auth_db = _make_actionlog_auth_db()
+    repo_db = _make_actionlog_read_db(actionlog_row=None)
+
+    with (
+        patch("auth.Database", return_value=auth_db),
+        patch("auth._resolve_user_id", return_value=1),
+        patch("handler.Database", return_value=repo_db),
+    ):
+        result = lambda_handler(
+            _make_direct_event("generateActionLogErrorReport", {"batchId": BATCH_ID}),
+            _make_ctx_mock(),
+        )
+
+    assert result["errorType"] == "BATCH_NOT_FOUND"
+
+
+def test_generate_error_report_s3_error_propagates() -> None:
+    """S3Error from put_csv propagates as S3_ERROR."""
+    from exceptions import S3Error
+
+    auth_db = _make_actionlog_auth_db()
+    repo_db = _make_actionlog_read_db(actionlog_row=_make_actionlog_row(), failed_rows=[])
+
+    with (
+        patch("auth.Database", return_value=auth_db),
+        patch("auth._resolve_user_id", return_value=1),
+        patch("handler.Database", return_value=repo_db),
+        patch("handler.put_csv", side_effect=S3Error("bucket unavailable")),
+    ):
+        result = lambda_handler(
+            _make_direct_event("generateActionLogErrorReport", {"batchId": BATCH_ID}),
+            _make_ctx_mock(),
+        )
+
+    assert result["errorType"] == "S3_ERROR"
+
+
+def test_generate_error_report_s3_key_contains_batch_id() -> None:
+    """S3 key passed to put_csv contains the batchId."""
+    auth_db = _make_actionlog_auth_db()
+    repo_db = _make_actionlog_read_db(actionlog_row=_make_actionlog_row(), failed_rows=[])
+    captured_keys: list[str] = []
+
+    def capture_put(key: str, body: bytes, **_kw: Any) -> None:
+        captured_keys.append(key)
+
+    with (
+        patch("auth.Database", return_value=auth_db),
+        patch("auth._resolve_user_id", return_value=1),
+        patch("handler.Database", return_value=repo_db),
+        patch("handler.put_csv", side_effect=capture_put),
+        patch("handler.presigned_get_url", return_value="https://s3.example.com/url"),
+    ):
+        lambda_handler(
+            _make_direct_event("generateActionLogErrorReport", {"batchId": BATCH_ID}),
+            _make_ctx_mock(),
+        )
+
+    assert len(captured_keys) == 1
+    assert BATCH_ID in captured_keys[0]

--- a/fluxion-backend/modules/action_resolver/tests/test_s3.py
+++ b/fluxion-backend/modules/action_resolver/tests/test_s3.py
@@ -1,0 +1,118 @@
+"""Tests for s3.put_csv and s3.presigned_get_url."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import s3 as s3_module
+from exceptions import S3Error
+
+
+def _make_client() -> MagicMock:
+    mock = MagicMock()
+    mock.put_object.return_value = {"ResponseMetadata": {"HTTPStatusCode": 200}}
+    mock.generate_presigned_url.return_value = "https://s3.example.com/presigned"
+    return mock
+
+
+class TestPutCsv:
+    def setup_method(self) -> None:
+        # Reset module-level singleton between tests.
+        s3_module._client = None
+
+    def test_happy_path_calls_put_object(self) -> None:
+        mock_client = _make_client()
+        with patch("s3._get_client", return_value=mock_client):
+            s3_module.put_csv("action-log-errors/abc.csv", b"data", bucket="test-bucket")
+
+        mock_client.put_object.assert_called_once_with(
+            Bucket="test-bucket",
+            Key="action-log-errors/abc.csv",
+            Body=b"data",
+            ContentType="text/csv",
+        )
+
+    def test_uses_env_bucket_when_not_overridden(self) -> None:
+        mock_client = _make_client()
+        with patch("s3._get_client", return_value=mock_client):
+            with patch("s3.UPLOADS_BUCKET", "env-bucket"):
+                s3_module.put_csv("key.csv", b"body")
+
+        call_kwargs = mock_client.put_object.call_args.kwargs
+        assert call_kwargs["Bucket"] == "env-bucket"
+
+    def test_client_error_raises_s3_error(self) -> None:
+        mock_client = _make_client()
+        mock_client.put_object.side_effect = Exception("connection refused")
+        with patch("s3._get_client", return_value=mock_client):
+            with pytest.raises(S3Error, match="put_object failed"):
+                s3_module.put_csv("key.csv", b"body", bucket="b")
+
+    def test_s3_error_message_includes_key(self) -> None:
+        mock_client = _make_client()
+        mock_client.put_object.side_effect = Exception("boom")
+        with patch("s3._get_client", return_value=mock_client):
+            with pytest.raises(S3Error) as exc_info:
+                s3_module.put_csv("errors/batch-123.csv", b"x", bucket="b")
+        assert "errors/batch-123.csv" in str(exc_info.value)
+
+
+class TestPresignedGetUrl:
+    def setup_method(self) -> None:
+        s3_module._client = None
+
+    def test_returns_url_string(self) -> None:
+        mock_client = _make_client()
+        with patch("s3._get_client", return_value=mock_client):
+            url = s3_module.presigned_get_url("action-log-errors/abc.csv", bucket="b")
+        assert url == "https://s3.example.com/presigned"
+
+    def test_calls_generate_presigned_url_with_correct_params(self) -> None:
+        mock_client = _make_client()
+        with patch("s3._get_client", return_value=mock_client):
+            s3_module.presigned_get_url("my/key.csv", ttl_seconds=180, bucket="bkt")
+
+        mock_client.generate_presigned_url.assert_called_once_with(
+            "get_object",
+            Params={"Bucket": "bkt", "Key": "my/key.csv"},
+            ExpiresIn=180,
+        )
+
+    def test_default_ttl_is_300(self) -> None:
+        mock_client = _make_client()
+        with patch("s3._get_client", return_value=mock_client):
+            s3_module.presigned_get_url("key.csv", bucket="b")
+
+        call_kwargs = mock_client.generate_presigned_url.call_args.kwargs
+        assert call_kwargs["ExpiresIn"] == 300
+
+    def test_client_error_raises_s3_error(self) -> None:
+        mock_client = _make_client()
+        mock_client.generate_presigned_url.side_effect = Exception("forbidden")
+        with patch("s3._get_client", return_value=mock_client):
+            with pytest.raises(S3Error, match="presign failed"):
+                s3_module.presigned_get_url("key.csv", bucket="b")
+
+    def test_uses_env_bucket_when_not_overridden(self) -> None:
+        mock_client = _make_client()
+        with patch("s3._get_client", return_value=mock_client):
+            with patch("s3.UPLOADS_BUCKET", "env-bucket"):
+                s3_module.presigned_get_url("key.csv")
+
+        call_kwargs = mock_client.generate_presigned_url.call_args.kwargs
+        assert call_kwargs["Params"]["Bucket"] == "env-bucket"
+
+
+class TestGetClientSingleton:
+    def setup_method(self) -> None:
+        s3_module._client = None
+
+    def test_singleton_reused_across_calls(self) -> None:
+        mock_client = _make_client()
+        with patch("s3._get_client", return_value=mock_client) as mock_get:
+            s3_module.put_csv("k.csv", b"x", bucket="b")
+            s3_module.put_csv("k2.csv", b"y", bucket="b")
+        # _get_client called once per put_csv (function is patched, not the real lazy init)
+        assert mock_get.call_count == 2

--- a/fluxion-backend/modules/action_resolver/tests/test_sqs.py
+++ b/fluxion-backend/modules/action_resolver/tests/test_sqs.py
@@ -1,0 +1,139 @@
+"""Tests for action_resolver sqs.py — thin boto3 SQS wrapper.
+
+Covers:
+  - Happy path: enqueue_action_trigger returns MessageId
+  - boto3 ClientError → SqsError raised
+  - Non-ClientError exception → SqsError raised
+  - Queue URL override (used in tests)
+  - Lazy client singleton reuse
+
+boto3 is imported lazily inside _get_client(); tests patch sqs._get_client
+rather than sqs.boto3 to avoid import-time attribute errors.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import sqs as sqs_module
+from exceptions import SqsError
+
+QUEUE_URL = "https://sqs.us-east-1.amazonaws.com/000000000000/test-queue"
+DEVICE_ID = str(uuid.uuid4())
+BATCH_ID = str(uuid.uuid4())
+
+
+def _make_envelope() -> dict[str, Any]:
+    return {
+        "batchId": BATCH_ID,
+        "deviceId": DEVICE_ID,
+        "actionId": str(uuid.uuid4()),
+        "executionId": str(uuid.uuid4()),
+        "commandUuid": str(uuid.uuid4()),
+        "configuration": None,
+        "tenant_schema": "dev1",
+    }
+
+
+def _make_mock_client(message_id: str = "msg-123") -> MagicMock:
+    """Build a mock boto3 SQS client."""
+    client = MagicMock()
+    client.send_message.return_value = {"MessageId": message_id}
+    return client
+
+
+def test_enqueue_action_trigger_happy_path() -> None:
+    """Happy path: returns MessageId string from SQS response."""
+    mock_client = _make_mock_client("msg-123")
+
+    with patch("sqs._get_client", return_value=mock_client):
+        result = sqs_module.enqueue_action_trigger(_make_envelope(), queue_url=QUEUE_URL)
+
+    assert result == "msg-123"
+    mock_client.send_message.assert_called_once()
+    call_kwargs = mock_client.send_message.call_args
+    assert call_kwargs.kwargs["QueueUrl"] == QUEUE_URL
+    body = json.loads(call_kwargs.kwargs["MessageBody"])
+    assert body["deviceId"] == DEVICE_ID
+
+
+def test_enqueue_action_trigger_sends_correct_json_body() -> None:
+    """MessageBody is valid JSON containing all envelope fields including messageContent."""
+    envelope = _make_envelope()
+    envelope["messageContent"] = "Lock your device"
+    mock_client = _make_mock_client("msg-456")
+
+    with patch("sqs._get_client", return_value=mock_client):
+        sqs_module.enqueue_action_trigger(envelope, queue_url=QUEUE_URL)
+
+    sent_body = json.loads(mock_client.send_message.call_args.kwargs["MessageBody"])
+    assert sent_body["messageContent"] == "Lock your device"
+    assert sent_body["tenant_schema"] == "dev1"
+    assert sent_body["batchId"] == BATCH_ID
+
+
+def test_enqueue_action_trigger_client_error_raises_sqs_error() -> None:
+    """boto3 ClientError → SqsError raised with 'SQS send_message failed' message."""
+    try:
+        from botocore.exceptions import ClientError
+    except ImportError:
+        pytest.skip("botocore not installed")
+
+    mock_client = MagicMock()
+    mock_client.send_message.side_effect = ClientError(
+        {"Error": {"Code": "AccessDenied", "Message": "no access"}}, "SendMessage"
+    )
+
+    with patch("sqs._get_client", return_value=mock_client):
+        with pytest.raises(SqsError, match="SQS send_message failed"):
+            sqs_module.enqueue_action_trigger(_make_envelope(), queue_url=QUEUE_URL)
+
+
+def test_enqueue_action_trigger_unexpected_error_raises_sqs_error() -> None:
+    """Unexpected non-ClientError exception → SqsError with 'unexpected error' message."""
+    mock_client = MagicMock()
+    mock_client.send_message.side_effect = RuntimeError("unexpected boom")
+
+    with patch("sqs._get_client", return_value=mock_client):
+        with pytest.raises(SqsError, match="SQS send_message unexpected error"):
+            sqs_module.enqueue_action_trigger(_make_envelope(), queue_url=QUEUE_URL)
+
+
+def test_enqueue_uses_default_queue_url_from_config() -> None:
+    """When queue_url not provided, falls back to ACTION_TRIGGER_QUEUE_URL config."""
+    mock_client = _make_mock_client("msg-789")
+
+    with (
+        patch("sqs._get_client", return_value=mock_client),
+        patch("sqs.ACTION_TRIGGER_QUEUE_URL", "https://sqs.example.com/default-queue"),
+    ):
+        sqs_module.enqueue_action_trigger(_make_envelope())
+
+    call_kwargs = mock_client.send_message.call_args
+    assert call_kwargs.kwargs["QueueUrl"] == "https://sqs.example.com/default-queue"
+
+
+def test_enqueue_reuses_lazy_client_singleton() -> None:
+    """_get_client is called each time but returns the same cached instance."""
+    mock_client = _make_mock_client()
+
+    # Reset the module-level singleton so we exercise the caching path.
+    sqs_module._client = None  # type: ignore[attr-defined]
+
+    call_count = 0
+
+    def fake_get_client() -> MagicMock:
+        nonlocal call_count
+        call_count += 1
+        return mock_client
+
+    with patch("sqs._get_client", side_effect=fake_get_client):
+        sqs_module.enqueue_action_trigger(_make_envelope(), queue_url=QUEUE_URL)
+        sqs_module.enqueue_action_trigger(_make_envelope(), queue_url=QUEUE_URL)
+
+    assert mock_client.send_message.call_count == 2

--- a/fluxion-backend/modules/upload_resolver/Dockerfile
+++ b/fluxion-backend/modules/upload_resolver/Dockerfile
@@ -1,0 +1,17 @@
+# upload_resolver Lambda container image.
+# Self-contained: no dependency on a workspace-built base image.
+# Build context (from CI/.github/workflows/deploy.yml): fluxion-backend/
+
+FROM public.ecr.aws/lambda/python:3.12
+
+RUN pip install --no-cache-dir \
+    "psycopg[binary]>=3.1,<4" \
+    "pydantic>=2.6" \
+    "aws-lambda-powertools>=2.30" \
+    "boto3>=1.34"
+
+# Source — flat-COPY into LAMBDA_TASK_ROOT so imports resolve as
+# `from config import X` (mirrors pytest pythonpath = ["src"]).
+COPY modules/upload_resolver/src/ ${LAMBDA_TASK_ROOT}/
+
+CMD ["handler.lambda_handler"]

--- a/fluxion-backend/modules/upload_resolver/pyproject.toml
+++ b/fluxion-backend/modules/upload_resolver/pyproject.toml
@@ -1,0 +1,42 @@
+[project]
+name = "upload-resolver"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+    "psycopg[binary]>=3.1,<4",
+    "pydantic>=2.6",
+    "aws-lambda-powertools>=2.30",
+    "boto3>=1.34",
+]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths = ["tests"]
+addopts = "--cov=src --cov-report=term-missing --cov-fail-under=80"
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "N", "W", "UP"]
+ignore = ["E501", "N815", "N806"]  # N815: camelCase Pydantic fields; N806: MockDB test vars
+
+[tool.mypy]
+strict = true
+python_version = "3.12"
+explicit_package_bases = true
+mypy_path = "src"
+# handler.py uses decorator-transformed callables whose post-decoration signature
+# mypy cannot always reconstruct. Exclude from strict.
+exclude = ["src/handler\\.py"]
+
+[[tool.mypy.overrides]]
+# Local Lambda modules have no py.typed — ignore missing stubs for intra-module imports.
+module = ["auth", "config", "db", "exceptions", "schema_types", "sqs", "permissions"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+# boto3 / botocore ship no py.typed markers or bundled stubs.
+module = ["boto3", "botocore", "botocore.exceptions"]
+ignore_missing_imports = true

--- a/fluxion-backend/modules/upload_resolver/src/auth.py
+++ b/fluxion-backend/modules/upload_resolver/src/auth.py
@@ -1,0 +1,203 @@
+"""Auth helpers: context extraction + permission decorator.
+
+Two public symbols:
+  - ``build_context_from(event)`` — parses Cognito claims into a ``Context``.
+  - ``permission_required(permission)`` — decorator that enforces a permission code.
+  - ``validate_input(model, key)`` — decorator that validates args against a Pydantic model.
+
+Design-patterns.md §11.2: tenant_schema is resolved from the validated
+Cognito ``custom:tenant_id`` claim via accesscontrol.tenants lookup.
+``cognito_sub`` comes from ``event["identity"]["claims"]["sub"]`` which
+AppSync already verified — no re-verification needed.
+"""
+
+from __future__ import annotations
+
+import functools
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, TypeVar
+
+from pydantic import BaseModel
+
+from config import logger
+from db import Database
+from exceptions import AuthenticationError, ForbiddenError, InvalidInputError
+
+F = TypeVar("F", bound=Callable[..., Any])
+M = TypeVar("M", bound=BaseModel)
+
+
+@dataclass(frozen=True, slots=True)
+class Context:
+    """Resolved caller context, populated once per Lambda invocation.
+
+    Attributes:
+        cognito_sub: Cognito user subject UUID (from JWT claim ``sub``).
+        user_id: ``accesscontrol.users.id`` for this subject.
+        tenant_id: ``accesscontrol.tenants.id`` (BIGINT) from Cognito claim.
+        tenant_schema: Validated bare schema name (e.g. ``"dev1"``).
+    """
+
+    cognito_sub: str
+    user_id: int
+    tenant_id: int
+    tenant_schema: str
+
+
+def build_context_from(event: dict[str, Any]) -> Context:
+    """Extract and resolve caller identity from an AppSync resolver event.
+
+    Flow (per design-patterns.md §11.2):
+    1. Read ``cognito_sub`` from ``event["identity"]["claims"]["sub"]``.
+    2. Read ``tenant_id`` (BIGINT) from ``event["identity"]["claims"]["custom:tenant_id"]``.
+    3. Look up ``accesscontrol.users`` to get ``user_id``.
+    4. Look up ``accesscontrol.tenants`` to get validated ``schema_name``.
+
+    Args:
+        event: Raw AppSync Lambda resolver event.
+
+    Returns:
+        Populated ``Context`` for this invocation.
+
+    Raises:
+        AuthenticationError: Claims missing or identity block absent.
+        InvalidInputError: ``custom:tenant_id`` claim is not a valid integer.
+    """
+    try:
+        claims: dict[str, Any] = event["identity"]["claims"]
+        cognito_sub: str = claims["sub"]
+        raw_tenant_id: str = claims["custom:tenant_id"]
+    except (KeyError, TypeError) as exc:
+        raise AuthenticationError("missing identity claims") from exc
+
+    try:
+        tenant_id = int(raw_tenant_id)
+    except (ValueError, TypeError) as exc:
+        raise InvalidInputError(f"custom:tenant_id is not an integer: {raw_tenant_id!r}") from exc
+
+    with Database() as db:
+        tenant_schema = db.get_schema_name(tenant_id)
+        user_id = _resolve_user_id(db, cognito_sub)
+
+    return Context(
+        cognito_sub=cognito_sub,
+        user_id=user_id,
+        tenant_id=tenant_id,
+        tenant_schema=tenant_schema,
+    )
+
+
+def permission_required(permission: str) -> Callable[[F], F]:
+    """Decorator: resolve caller context and enforce a permission code.
+
+    Wraps a field handler ``(args, ctx, correlation_id) -> Any``.
+    Injects the resolved ``Context`` as ``ctx`` — the wrapped function
+    does NOT need to call ``build_context_from`` itself.
+
+    Args:
+        permission: Permission code to enforce (e.g. ``"upload:write"``).
+
+    Returns:
+        Decorator that injects ``ctx`` and raises ``ForbiddenError`` on miss.
+
+    Raises:
+        ForbiddenError: User does not hold the permission for the tenant.
+    """
+
+    def decorator(fn: F) -> F:
+        @functools.wraps(fn)
+        def wrapper(
+            args: dict[str, Any],
+            event: dict[str, Any],
+            correlation_id: str,
+        ) -> Any:
+            ctx = build_context_from(event)
+            with Database() as db:
+                if not db.has_permission(ctx.cognito_sub, ctx.tenant_id, permission):
+                    logger.warning(
+                        "auth.permission_denied",
+                        extra={
+                            "permission": permission,
+                            "cognito_sub": ctx.cognito_sub,
+                            "tenant_id": ctx.tenant_id,
+                            "correlation_id": correlation_id,
+                        },
+                    )
+                    raise ForbiddenError(f"missing permission: {permission}")
+            return fn(args, ctx, correlation_id)
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator
+
+
+def validate_input(model: type[M], key: str | None = None) -> Callable[[F], F]:  # noqa: UP047
+    """Decorator: validate an input dict against a Pydantic model.
+
+    The validated instance is appended as the last positional arg to the wrapped fn.
+    Wrapped signature: ``(args, ctx, correlation_id, inp)``.
+
+    Args:
+        model: Pydantic model class to validate against.
+        key: If set, validate ``args[key]`` (default empty dict if missing) instead
+            of ``args``. Use ``key="input"`` for AppSync mutation handlers.
+
+    Raises:
+        InvalidInputError: Validation failed.
+    """
+
+    def decorator(fn: F) -> F:
+        @functools.wraps(fn)
+        def wrapper(
+            args: dict[str, Any],
+            ctx: Context,
+            correlation_id: str,
+        ) -> Any:
+            raw: Any = args if key is None else args.get(key, {})
+            try:
+                inp = model.model_validate(raw)
+            except Exception as exc:
+                raise InvalidInputError(str(exc)) from exc
+            return fn(args, ctx, correlation_id, inp)
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator
+
+
+# ------------------------------------------------------------------
+# Internal helpers
+# ------------------------------------------------------------------
+
+
+def _resolve_user_id(db: Database, cognito_sub: str) -> int:
+    """Fetch accesscontrol.users.id for a cognito_sub.
+
+    Args:
+        db: Open Database instance (inside context manager).
+        cognito_sub: Cognito subject claim.
+
+    Returns:
+        Integer ``accesscontrol.users.id``.
+
+    Raises:
+        AuthenticationError: No user row found for this cognito_sub.
+    """
+    from exceptions import DatabaseError  # local import avoids circular at module level
+
+    conn = db._require_conn()  # noqa: SLF001 — auth.py is a sibling module, not external
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT id FROM accesscontrol.users WHERE cognito_sub = %s",
+                (cognito_sub,),
+            )
+            row = cur.fetchone()
+    except Exception as exc:
+        raise DatabaseError("user lookup failed") from exc
+
+    if not row:
+        raise AuthenticationError(f"no user for cognito_sub={cognito_sub!r}")
+
+    return int(row["id"])

--- a/fluxion-backend/modules/upload_resolver/src/config.py
+++ b/fluxion-backend/modules/upload_resolver/src/config.py
@@ -1,0 +1,35 @@
+"""Environment variables and logger — single source of truth for upload_resolver Lambda.
+
+All handlers and services import `logger` (and any env var constants) from here.
+Never call `os.environ` directly in other modules (see design-patterns.md §4).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+LOG_LEVEL: str = os.environ.get("LOG_LEVEL", "INFO")
+POWERTOOLS_SERVICE_NAME: str = os.environ.get("POWERTOOLS_SERVICE_NAME", "upload_resolver")
+
+logging.basicConfig(
+    level=LOG_LEVEL,
+    format='{"level":"%(levelname)s","service":"%(name)s","message":"%(message)s"}',
+)
+logger: logging.Logger = logging.getLogger(POWERTOOLS_SERVICE_NAME)
+
+# ---------------------------------------------------------------------------
+# Required environment variables
+# ---------------------------------------------------------------------------
+
+# DATABASE_URI must be set for any Lambda that uses db.py.
+# Safe default so unit tests can import config without a real DB present.
+DATABASE_URI: str = os.environ.get("DATABASE_URI", "")
+
+# UPLOAD_PROCESSOR_QUEUE_URL is the SQS queue URL for the upload-processor consumer.
+# Must be injected at Lambda cold start; empty string is safe for unit tests.
+UPLOAD_PROCESSOR_QUEUE_URL: str = os.environ.get("UPLOAD_PROCESSOR_QUEUE_URL", "")

--- a/fluxion-backend/modules/upload_resolver/src/db.py
+++ b/fluxion-backend/modules/upload_resolver/src/db.py
@@ -1,0 +1,221 @@
+"""psycopg3 repository for upload_resolver.
+
+Tenant-isolated: every SQL query uses psycopg.sql.Identifier for schema names.
+Never use f-string interpolation for schema names (SQL injection defense).
+
+Tables used:
+  accesscontrol.tenants        — id BIGINT, schema_name TEXT
+  accesscontrol.users          — id BIGINT, cognito_sub TEXT
+  accesscontrol.users_permissions — user_id, permission_id, tenant_id
+  accesscontrol.permissions    — id, code TEXT
+
+  Per-tenant schema:
+  device_informations          — serial_number TEXT UNIQUE, udid TEXT UNIQUE
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, NamedTuple
+
+import psycopg
+import psycopg.rows
+import psycopg.sql
+
+from config import DATABASE_URI, logger
+from exceptions import DatabaseError, TenantNotFoundError
+
+# Matches accesscontrol.tenants.ck_tenants_schema_name_format.
+_SCHEMA_NAME_RE: re.Pattern[str] = re.compile(r"^[a-z][a-z0-9_]{0,39}$")
+
+
+def _validate_schema(schema_name: str) -> str:
+    """Raise DatabaseError if schema_name fails the safety regex."""
+    if not _SCHEMA_NAME_RE.fullmatch(schema_name):
+        raise DatabaseError(f"invalid schema_name: {schema_name!r}")
+    return schema_name
+
+
+class ExistingDeviceKeys(NamedTuple):
+    """Sets of serial_numbers and udids that already exist in the tenant schema."""
+
+    serials: set[str]
+    udids: set[str]
+
+
+class Database:
+    """psycopg3 connection bound to a single Lambda invocation.
+
+    Context-manager only — do not use outside ``with Database() as db:``.
+    All schema-qualified SQL uses ``psycopg.sql.Identifier`` — never f-string.
+
+    Raises:
+        DatabaseError: If the initial connection fails.
+    """
+
+    def __init__(self) -> None:
+        self._conn: psycopg.Connection[Any] | None = None
+
+    def __enter__(self) -> Database:
+        try:
+            self._conn = psycopg.connect(DATABASE_URI, row_factory=psycopg.rows.dict_row)
+        except psycopg.Error as exc:
+            logger.exception("db.connect_failed")
+            raise DatabaseError("database connection failed") from exc
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        if self._conn is not None:
+            try:
+                self._conn.close()
+            except psycopg.Error:
+                logger.warning("db.close_failed")
+            finally:
+                self._conn = None
+
+    # ------------------------------------------------------------------
+    # accesscontrol helpers (shared with auth.py)
+    # ------------------------------------------------------------------
+
+    def get_schema_name(self, tenant_id: int) -> str:
+        """Resolve tenant BIGINT id → validated schema name.
+
+        Args:
+            tenant_id: The tenant id from the Cognito auth claim.
+
+        Returns:
+            Validated schema name (e.g. ``"dev1"``).
+
+        Raises:
+            TenantNotFoundError: No row exists for tenant_id.
+            DatabaseError: Query failed or schema name fails regex.
+        """
+        conn = self._require_conn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT schema_name FROM accesscontrol.tenants WHERE id = %s",
+                    (tenant_id,),
+                )
+                row = cur.fetchone()
+        except psycopg.Error as exc:
+            logger.exception("db.get_schema_name_failed", extra={"tenant_id": tenant_id})
+            raise DatabaseError("tenant lookup failed") from exc
+
+        if not row:
+            raise TenantNotFoundError(str(tenant_id))
+
+        return _validate_schema(str(row["schema_name"]))
+
+    def has_permission(self, cognito_sub: str, tenant_id: int, code: str) -> bool:
+        """Return True if user holds permission code for the tenant (or globally).
+
+        Args:
+            cognito_sub: User's Cognito subject claim.
+            tenant_id:   Tenant BIGINT id.
+            code:        Permission code (e.g. ``"upload:write"``).
+
+        Raises:
+            DatabaseError: Query execution failed.
+        """
+        conn = self._require_conn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT 1
+                    FROM accesscontrol.users u
+                    JOIN accesscontrol.users_permissions up ON u.id = up.user_id
+                    JOIN accesscontrol.permissions p       ON p.id = up.permission_id
+                    WHERE u.cognito_sub = %s
+                      AND p.code = %s
+                      AND (up.tenant_id = %s OR up.tenant_id IS NULL)
+                    LIMIT 1
+                    """,
+                    (cognito_sub, code, tenant_id),
+                )
+                return cur.fetchone() is not None
+        except psycopg.Error as exc:
+            logger.exception(
+                "db.has_permission_failed",
+                extra={"cognito_sub": cognito_sub, "code": code},
+            )
+            raise DatabaseError("permission check failed") from exc
+
+    # ------------------------------------------------------------------
+    # Upload-resolver repo methods
+    # ------------------------------------------------------------------
+
+    def find_existing_device_keys(
+        self,
+        serials: list[str],
+        udids: list[str],
+        schema: str,
+    ) -> ExistingDeviceKeys:
+        """Return serial_numbers and udids that already exist in the tenant schema.
+
+        Uses a single ``WHERE serial_number = ANY(...) OR udid = ANY(...)`` query.
+        Both columns are UNIQUE-indexed so this is cheap.
+
+        Args:
+            serials: List of serial_number strings to check.
+            udids:   List of udid strings to check.
+            schema:  Validated tenant schema name.
+
+        Returns:
+            ``ExistingDeviceKeys(serials=set, udids=set)`` — sets of already-existing
+            values. Either set may be empty if none of the given values conflict.
+
+        Raises:
+            DatabaseError: Query failed.
+        """
+        _validate_schema(schema)
+        conn = self._require_conn()
+
+        # Empty inputs: skip query and return empty sets (nothing can conflict).
+        if not serials and not udids:
+            return ExistingDeviceKeys(serials=set(), udids=set())
+
+        # Normalize to non-empty lists for ANY() parameterization.
+        # psycopg requires at least one element per array literal.
+        safe_serials = serials if serials else ["__no_match__"]
+        safe_udids = udids if udids else ["__no_match__"]
+
+        query = psycopg.sql.SQL(
+            """
+            SELECT serial_number, udid
+            FROM   {schema}.device_informations
+            WHERE  serial_number = ANY(%s)
+               OR  udid = ANY(%s)
+            """
+        ).format(schema=psycopg.sql.Identifier(schema))
+
+        try:
+            with conn.cursor() as cur:
+                cur.execute(query, (safe_serials, safe_udids))
+                rows = cur.fetchall()
+        except psycopg.Error as exc:
+            logger.exception(
+                "db.find_existing_device_keys_failed",
+                extra={"schema": schema, "serial_count": len(serials), "udid_count": len(udids)},
+            )
+            raise DatabaseError("find_existing_device_keys query failed") from exc
+
+        existing_serials: set[str] = set()
+        existing_udids: set[str] = set()
+        for row in rows:
+            if row["serial_number"] is not None:
+                existing_serials.add(str(row["serial_number"]))
+            if row["udid"] is not None:
+                existing_udids.add(str(row["udid"]))
+
+        return ExistingDeviceKeys(serials=existing_serials, udids=existing_udids)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _require_conn(self) -> psycopg.Connection[Any]:
+        if self._conn is None:
+            raise DatabaseError("Database used outside context manager")
+        return self._conn

--- a/fluxion-backend/modules/upload_resolver/src/exceptions.py
+++ b/fluxion-backend/modules/upload_resolver/src/exceptions.py
@@ -1,0 +1,102 @@
+"""Domain exceptions for upload_resolver Lambda.
+
+All errors extend ``FluxionError`` so the handler boundary catches one type
+and maps to AppSync error responses consistently (design-patterns.md §4).
+
+``to_appsync_error()`` on the base produces ``{"errorType", "errorMessage"}``
+as expected by AppSync Lambda direct resolvers.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class FluxionError(Exception):
+    """Base class for all Fluxion domain errors.
+
+    Subclasses set ``code`` and ``http_status`` as class attributes.
+    The handler catches ``FluxionError`` and calls ``to_appsync_error()``.
+
+    Args:
+        message: Human-readable error description.
+    """
+
+    code: str = "INTERNAL_ERROR"
+    http_status: int = 500
+
+    def to_appsync_error(self) -> dict[str, Any]:
+        """Serialize to AppSync Lambda direct resolver error shape.
+
+        Returns:
+            ``{"errorType": <code>, "errorMessage": <message>}`` dict.
+        """
+        return {
+            "errorType": self.code,
+            "errorMessage": str(self) or self.code,
+        }
+
+
+class DatabaseError(FluxionError):
+    """Database operation failed (connection, query, constraint)."""
+
+    code = "DATABASE_ERROR"
+    http_status = 503
+
+
+class TenantNotFoundError(FluxionError):
+    """Tenant id has no matching row in ``accesscontrol.tenants``."""
+
+    code = "TENANT_NOT_FOUND"
+    http_status = 404
+
+
+class ForbiddenError(FluxionError):
+    """Caller lacks a required permission."""
+
+    code = "FORBIDDEN"
+    http_status = 403
+
+
+class AuthenticationError(FluxionError):
+    """Identity claims missing or unresolvable."""
+
+    code = "UNAUTHENTICATED"
+    http_status = 401
+
+
+class InvalidInputError(FluxionError):
+    """Client-supplied input failed validation."""
+
+    code = "INVALID_INPUT"
+    http_status = 400
+
+
+class UnknownFieldError(FluxionError):
+    """GraphQL field name not registered in ``FIELD_HANDLERS``."""
+
+    code = "UNKNOWN_FIELD"
+    http_status = 400
+
+
+class SqsError(FluxionError):
+    """SQS SendMessage failed.
+
+    Raised by ``sqs.py``; callers log and suppress after the dedupe decision
+    so the request succeeds (fire-and-forget after the validation commit point).
+    """
+
+    code = "SQS_ERROR"
+    http_status = 503
+
+
+def to_appsync_error(exc: FluxionError) -> dict[str, Any]:
+    """Functional alias for ``exc.to_appsync_error()``.
+
+    Args:
+        exc: Any ``FluxionError`` subclass instance.
+
+    Returns:
+        ``{"errorType": <code>, "errorMessage": <message>}`` dict.
+    """
+    return exc.to_appsync_error()

--- a/fluxion-backend/modules/upload_resolver/src/handler.py
+++ b/fluxion-backend/modules/upload_resolver/src/handler.py
@@ -1,0 +1,253 @@
+"""Lambda entry point — AppSync field dispatch for upload_resolver.
+
+Fields handled:
+  uploadDevices(devices: [UploadDeviceInput!]!) → UploadResult!
+
+uploadDevices implements bulk device intake:
+  1. Parse + cap-validate the input (Pydantic, max 1000 devices).
+  2. Per-device: check for empty serialNumber / udid → MISSING_FIELD.
+  3. Request-level dedupe: track seen serials + udids → DUPLICATE_IN_REQUEST.
+  4. Single DB query for existing keys → DUPLICATE_EXISTING_SERIAL / UDID.
+  5. Enqueue one SQS message per accepted device (fire-and-forget post-dedupe).
+  6. Return aggregate UploadResult.
+
+Error codes used in UploadError.reason:
+  MISSING_FIELD             — serialNumber or udid is empty / missing.
+  DUPLICATE_IN_REQUEST      — same serialNumber or udid appears twice in the input.
+  DUPLICATE_EXISTING_SERIAL — serialNumber already exists in device_informations.
+  DUPLICATE_EXISTING_UDID   — udid already exists in device_informations.
+
+Race note: the DB dedupe check and SQS enqueue are not atomic. The
+upload-processor consumer is the sole writer to device_informations and MUST
+handle UNIQUE-violation gracefully (its concern, not ours). Rare concurrent
+uploads of the same serial from different callers may both pass the dedupe check
+here; only one will succeed at the consumer level. This is an acceptable race for
+human-ops workflows (GH-35 risk table).
+
+SQS fire-and-forget: if SendMessage fails after the dedupe decision the device
+is counted as accepted but will not be created. This matches the P1a pattern
+(post-commit SQS failure is surfaced by the consumer, not the resolver).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from auth import Context, permission_required, validate_input
+from config import logger
+from db import Database
+from exceptions import FluxionError, SqsError, UnknownFieldError
+from permissions import PERM_UPLOAD_WRITE
+from schema_types import (
+    UploadDeviceInputModel,
+    UploadDevicesInput,
+    UploadErrorResponse,
+    UploadResultResponse,
+)
+from sqs import enqueue_upload
+
+FieldHandler = Callable[[dict[str, Any], Any, str], Any]
+
+
+# ---------------------------------------------------------------------------
+# Field handler
+# ---------------------------------------------------------------------------
+
+
+@permission_required(PERM_UPLOAD_WRITE)
+@validate_input(UploadDevicesInput)
+def upload_devices(
+    _args: dict[str, Any],
+    ctx: Context,
+    correlation_id: str,
+    inp: UploadDevicesInput,
+) -> dict[str, Any]:
+    """Handle uploadDevices mutation — bulk device intake with per-device error reporting.
+
+    Returns an UploadResult even when all devices are rejected (no exception raised).
+
+    Args:
+        _args:          Raw arguments dict (pre-parsed via validate_input).
+        ctx:            Resolved caller context (injected by permission_required).
+        correlation_id: AWS request ID for tracing.
+        inp:            Validated UploadDevicesInput.
+
+    Returns:
+        UploadResultResponse dict matching GraphQL type.
+    """
+    devices = inp.devices
+    total = len(devices)
+
+    # Short-circuit: empty input → trivial success.
+    if total == 0:
+        return UploadResultResponse.build(total=0, accepted=0, errors=[]).model_dump()
+
+    errors: list[UploadErrorResponse] = []
+    # (original_index, device) tuples that survived per-device checks.
+    candidates: list[tuple[int, UploadDeviceInputModel]] = []
+
+    seen_serials: set[str] = set()
+    seen_udids: set[str] = set()
+
+    # Pass 1: per-device validation + request-level dedupe.
+    for i, device in enumerate(devices):
+        serial = device.serialNumber
+        udid = device.udid
+
+        if not serial:
+            errors.append(
+                UploadErrorResponse.build(
+                    index=i,
+                    reason="MISSING_FIELD: serialNumber is required",
+                    serial_number=None,
+                )
+            )
+            continue
+
+        if not udid:
+            errors.append(
+                UploadErrorResponse.build(
+                    index=i,
+                    reason="MISSING_FIELD: udid is required",
+                    serial_number=serial,
+                )
+            )
+            continue
+
+        if serial in seen_serials:
+            errors.append(
+                UploadErrorResponse.build(
+                    index=i,
+                    reason=f"DUPLICATE_IN_REQUEST: serialNumber {serial!r} already in this batch",
+                    serial_number=serial,
+                )
+            )
+            continue
+
+        if udid in seen_udids:
+            errors.append(
+                UploadErrorResponse.build(
+                    index=i,
+                    reason=f"DUPLICATE_IN_REQUEST: udid {udid!r} already in this batch",
+                    serial_number=serial,
+                )
+            )
+            continue
+
+        seen_serials.add(serial)
+        seen_udids.add(udid)
+        candidates.append((i, device))
+
+    # Pass 2: DB dedupe (single query for all candidate serials + udids).
+    accepted: list[UploadDeviceInputModel] = []
+
+    if candidates:
+        candidate_serials = [d.serialNumber for _, d in candidates]
+        candidate_udids = [d.udid for _, d in candidates]
+
+        with Database() as db:
+            existing = db.find_existing_device_keys(
+                candidate_serials, candidate_udids, ctx.tenant_schema
+            )
+
+        for i, device in candidates:
+            if device.serialNumber in existing.serials:
+                errors.append(
+                    UploadErrorResponse.build(
+                        index=i,
+                        reason=(
+                            f"DUPLICATE_EXISTING_SERIAL: serialNumber {device.serialNumber!r}"
+                            " already exists"
+                        ),
+                        serial_number=device.serialNumber,
+                    )
+                )
+            elif device.udid in existing.udids:
+                errors.append(
+                    UploadErrorResponse.build(
+                        index=i,
+                        reason=f"DUPLICATE_EXISTING_UDID: udid {device.udid!r} already exists",
+                        serial_number=device.serialNumber,
+                    )
+                )
+            else:
+                accepted.append(device)
+
+    # Pass 3: SQS enqueue per accepted device (fire-and-forget).
+    for device in accepted:
+        envelope: dict[str, Any] = {
+            "tenant_schema": ctx.tenant_schema,
+            "serialNumber": device.serialNumber,
+            "udid": device.udid,
+            "name": device.name,
+            "model": device.model,
+            "osVersion": device.osVersion,
+        }
+        try:
+            msg_id = enqueue_upload(envelope)
+            logger.info(
+                "sqs.upload_enqueued",
+                extra={
+                    "serial_number": device.serialNumber,
+                    "sqs_message_id": msg_id,
+                    "correlation_id": correlation_id,
+                },
+            )
+        except SqsError:
+            # Post-dedupe SQS failure: device is counted as accepted but will not
+            # be created. Consumer is responsible for UNIQUE violations. See module
+            # docstring for full rationale.
+            logger.error(
+                "sqs.upload_enqueue_failed",
+                extra={
+                    "serial_number": device.serialNumber,
+                    "correlation_id": correlation_id,
+                },
+            )
+
+    logger.info(
+        "upload_devices.complete",
+        extra={
+            "total": total,
+            "accepted": len(accepted),
+            "rejected": len(errors),
+            "correlation_id": correlation_id,
+        },
+    )
+
+    return UploadResultResponse.build(
+        total=total,
+        accepted=len(accepted),
+        errors=errors,
+    ).model_dump()
+
+
+# ---------------------------------------------------------------------------
+# Dispatch table + entry point
+# ---------------------------------------------------------------------------
+
+FIELD_HANDLERS: dict[str, FieldHandler] = {
+    "uploadDevices": upload_devices,
+}
+
+
+def lambda_handler(event: dict[str, Any], context: Any) -> Any:
+    """AppSync Lambda direct resolver entry point."""
+    correlation_id: str = getattr(context, "aws_request_id", "local")
+    field: str = event.get("info", {}).get("fieldName", "")
+
+    logger.info("resolver.invoked", extra={"field": field, "correlation_id": correlation_id})
+
+    try:
+        handler = FIELD_HANDLERS.get(field)
+        if handler is None:
+            raise UnknownFieldError(f"no handler for field: {field!r}")
+        result: Any = handler(event.get("arguments", {}), event, correlation_id)
+        return result
+    except FluxionError as exc:
+        logger.warning(
+            "resolver.error",
+            extra={"field": field, "error_type": exc.code, "correlation_id": correlation_id},
+        )
+        return exc.to_appsync_error()

--- a/fluxion-backend/modules/upload_resolver/src/permissions.py
+++ b/fluxion-backend/modules/upload_resolver/src/permissions.py
@@ -1,0 +1,12 @@
+"""Permission codes for upload_resolver.
+
+Must match rows seeded by the permission catalog migration into
+``accesscontrol.permissions`` (seeded in P0 of GH-35).
+
+Codes:
+  upload:write   — uploadDevices (P2)
+"""
+
+from __future__ import annotations
+
+PERM_UPLOAD_WRITE = "upload:write"

--- a/fluxion-backend/modules/upload_resolver/src/schema_types.py
+++ b/fluxion-backend/modules/upload_resolver/src/schema_types.py
@@ -1,0 +1,173 @@
+"""Pydantic v2 DTOs for upload_resolver — shaped to match schema.graphql exactly.
+
+AppSync receives whatever model_dump() emits, so field names MUST match
+GraphQL type field names (camelCase).
+
+GraphQL types handled:
+
+  type UploadResult {
+    totalRequested: Int!
+    accepted: Int!
+    rejected: Int!
+    errors: [UploadError!]
+  }
+
+  type UploadError {
+    index: Int!
+    serialNumber: String
+    reason: String!
+  }
+
+  input UploadDeviceInput {
+    serialNumber: String!
+    udid: String!
+    name: String
+    model: String
+    osVersion: String
+  }
+
+Notes:
+  - ``UploadDeviceInputModel`` does NOT validate empty strings in Pydantic —
+    per-device empty checks are done in the handler to produce ``MISSING_FIELD``
+    errors with the correct original index position. Pydantic enforces shape only.
+  - ``UploadDevicesInput.devices`` cap of 1000 is a whole-request failure via
+    field_validator (mirrors BulkAssignInput.deviceIds <= 500 in action_resolver).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+
+class BaseInput(BaseModel):
+    """Strict input base — unknown fields rejected immediately."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class BaseResponse(BaseModel):
+    """Permissive response base — forward-compatible with new server fields."""
+
+    model_config = ConfigDict(extra="allow")
+
+
+# ---------------------------------------------------------------------------
+# Input models
+# ---------------------------------------------------------------------------
+
+
+class UploadDeviceInputModel(BaseInput):
+    """Single device record from the UploadDeviceInput GraphQL input type.
+
+    Attributes:
+        serialNumber: Device serial number (non-empty validated at handler level).
+        udid:         Device UDID (non-empty validated at handler level).
+        name:         Optional display name.
+        model:        Optional hardware model string.
+        osVersion:    Optional OS version string.
+
+    Note:
+        Empty-string checks for serialNumber and udid are intentionally deferred
+        to the handler so that per-device MISSING_FIELD errors carry the correct
+        original index. Pydantic only enforces field presence and type here.
+    """
+
+    serialNumber: str
+    udid: str
+    name: str | None = None
+    model: str | None = None
+    osVersion: str | None = None
+
+
+class UploadDevicesInput(BaseModel):
+    """Wrapper input for the uploadDevices mutation.
+
+    Attributes:
+        devices: List of device records to upload (max 1000).
+
+    Note:
+        Uses extra="ignore" (not "forbid") because AppSync passes the raw
+        arguments dict directly (no "input" key wrapper for this mutation).
+    """
+
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    devices: list[UploadDeviceInputModel]
+
+    @field_validator("devices")
+    @classmethod
+    def _cap_devices(cls, v: list[UploadDeviceInputModel]) -> list[UploadDeviceInputModel]:
+        if len(v) > 1000:
+            raise ValueError(f"devices exceeds maximum of 1000 (got {len(v)})")
+        return v
+
+
+# ---------------------------------------------------------------------------
+# Response models
+# ---------------------------------------------------------------------------
+
+
+class UploadErrorResponse(BaseResponse):
+    """Per-device failure entry — matches GraphQL UploadError.
+
+    Attributes:
+        index:        Zero-based position of the device in the original input list.
+        serialNumber: Device serial number, or None when missing-field error occurs
+                      before the serial was determined.
+        reason:       Human-readable failure reason with error code prefix,
+                      e.g. ``"MISSING_FIELD: serialNumber is required"``.
+    """
+
+    index: int
+    serialNumber: str | None = None
+    reason: str
+
+    @classmethod
+    def build(
+        cls,
+        index: int,
+        reason: str,
+        serial_number: str | None = None,
+    ) -> UploadErrorResponse:
+        """Construct from handler fields."""
+        return cls(index=index, serialNumber=serial_number, reason=reason)
+
+
+class UploadResultResponse(BaseResponse):
+    """Bulk upload result — matches GraphQL UploadResult.
+
+    Attributes:
+        totalRequested: Total number of devices in the input list.
+        accepted:       Devices that passed validation and were enqueued.
+        rejected:       Devices that failed validation (len(errors)).
+        errors:         Per-device failure entries (null when empty is acceptable
+                        per schema: ``errors: [UploadError!]`` without ``!``).
+    """
+
+    totalRequested: int
+    accepted: int
+    rejected: int
+    errors: list[UploadErrorResponse]
+
+    @classmethod
+    def build(
+        cls,
+        total: int,
+        accepted: int,
+        errors: list[UploadErrorResponse],
+    ) -> UploadResultResponse:
+        """Construct from counts and error list."""
+        return cls(
+            totalRequested=total,
+            accepted=accepted,
+            rejected=len(errors),
+            errors=errors,
+        )
+
+    def model_dump(self, **kwargs: Any) -> dict[str, Any]:
+        """Serialize, converting nested UploadErrorResponse to dicts."""
+        d = super().model_dump(**kwargs)
+        d["errors"] = [e.model_dump() for e in self.errors]
+        return d

--- a/fluxion-backend/modules/upload_resolver/src/sqs.py
+++ b/fluxion-backend/modules/upload_resolver/src/sqs.py
@@ -1,0 +1,86 @@
+"""Thin boto3 SQS wrapper for upload_resolver.
+
+Sends device-upload messages to the configured SQS queue.
+Each message envelope:
+
+    {
+      "tenant_schema": <str>,
+      "serialNumber":  <str>,
+      "udid":          <str>,
+      "name":          <str | null>,
+      "model":         <str | null>,
+      "osVersion":     <str | null>
+    }
+
+SQS errors after the dedupe-passed decision are logged but NOT re-raised —
+the upload is considered accepted and the consumer is responsible for UNIQUE
+violations on the DB side. See handler.py docstring for rationale.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from config import UPLOAD_PROCESSOR_QUEUE_URL, logger
+from exceptions import SqsError
+
+# Lazy-init client: instantiated on first send, reused within the Lambda container.
+_client: Any = None
+
+
+def _get_client() -> Any:
+    """Return (or create) the boto3 SQS client.
+
+    Lazy init avoids import-time boto3 calls during unit tests.
+    """
+    global _client  # noqa: PLW0603
+    if _client is None:
+        import boto3  # deferred to avoid import cost when SQS is not needed
+
+        _client = boto3.client("sqs")
+    return _client
+
+
+def enqueue_upload(message_body: dict[str, Any], queue_url: str | None = None) -> str:
+    """Send a single device-upload message to SQS.
+
+    Args:
+        message_body: Dict conforming to the SQS envelope schema (see module docstring).
+        queue_url:    Override queue URL (used in tests); defaults to
+                      UPLOAD_PROCESSOR_QUEUE_URL.
+
+    Returns:
+        SQS ``MessageId`` string.
+
+    Raises:
+        SqsError: boto3 ``ClientError`` or unexpected error from SQS.
+    """
+    url = queue_url or UPLOAD_PROCESSOR_QUEUE_URL
+    try:
+        response: dict[str, Any] = _get_client().send_message(
+            QueueUrl=url,
+            MessageBody=json.dumps(message_body),
+        )
+        return str(response["MessageId"])
+    except Exception as exc:
+        # Import botocore lazily — it's always present when boto3 is installed.
+        try:
+            from botocore.exceptions import ClientError
+
+            if isinstance(exc, ClientError):
+                logger.error(
+                    "sqs.send_message_failed",
+                    extra={
+                        "serial_number": message_body.get("serialNumber"),
+                        "error": str(exc),
+                    },
+                )
+                raise SqsError(f"SQS send_message failed: {exc}") from exc
+        except ImportError:
+            pass
+        logger.error(
+            "sqs.send_message_unexpected_error",
+            extra={"error": str(exc)},
+        )
+        raise SqsError(f"SQS send_message unexpected error: {exc}") from exc

--- a/fluxion-backend/modules/upload_resolver/tests/conftest.py
+++ b/fluxion-backend/modules/upload_resolver/tests/conftest.py
@@ -1,0 +1,23 @@
+"""Shared pytest fixtures for upload_resolver Lambda tests.
+
+The autouse session fixture sets the minimum env vars required so that
+importing config.py does not fail during collection. No real DB or SQS needed.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _set_env() -> None:
+    """Set required environment variables for the test session."""
+    os.environ.setdefault("LOG_LEVEL", "DEBUG")
+    os.environ.setdefault("POWERTOOLS_SERVICE_NAME", "upload_resolver-test")
+    os.environ.setdefault("DATABASE_URI", "postgresql://localhost/test")
+    os.environ.setdefault(
+        "UPLOAD_PROCESSOR_QUEUE_URL",
+        "https://sqs.us-east-1.amazonaws.com/000000000000/upload-processor-test",
+    )

--- a/fluxion-backend/modules/upload_resolver/tests/test_db.py
+++ b/fluxion-backend/modules/upload_resolver/tests/test_db.py
@@ -1,0 +1,237 @@
+"""Unit tests for upload_resolver db.py.
+
+All tests use a mock psycopg connection — no real DB required.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from db import Database, ExistingDeviceKeys, _validate_schema
+from exceptions import DatabaseError, TenantNotFoundError
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_db(fetchone_return: Any = None, fetchall_return: Any = None) -> MagicMock:
+    """Build a mock Database that returns preset values from cursor methods."""
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_cur.__enter__ = MagicMock(return_value=mock_cur)
+    mock_cur.__exit__ = MagicMock(return_value=False)
+    mock_cur.fetchone.return_value = fetchone_return
+    mock_cur.fetchall.return_value = fetchall_return or []
+    mock_conn.cursor.return_value = mock_cur
+    return mock_conn
+
+
+# ---------------------------------------------------------------------------
+# _validate_schema
+# ---------------------------------------------------------------------------
+
+
+class TestValidateSchema:
+    def test_valid_simple(self) -> None:
+        assert _validate_schema("dev1") == "dev1"
+
+    def test_valid_with_underscore(self) -> None:
+        assert _validate_schema("tenant_abc") == "tenant_abc"
+
+    def test_valid_max_length(self) -> None:
+        name = "a" + "b" * 39  # 40 chars
+        assert _validate_schema(name) == name
+
+    def test_invalid_uppercase(self) -> None:
+        with pytest.raises(DatabaseError):
+            _validate_schema("DEV1")
+
+    def test_invalid_starts_with_digit(self) -> None:
+        with pytest.raises(DatabaseError):
+            _validate_schema("1dev")
+
+    def test_invalid_too_long(self) -> None:
+        with pytest.raises(DatabaseError):
+            _validate_schema("a" * 41)
+
+    def test_invalid_empty(self) -> None:
+        with pytest.raises(DatabaseError):
+            _validate_schema("")
+
+
+# ---------------------------------------------------------------------------
+# Database.get_schema_name
+# ---------------------------------------------------------------------------
+
+
+class TestGetSchemaName:
+    def test_returns_schema_name(self) -> None:
+        db = Database()
+        db._conn = _make_mock_db(fetchone_return={"schema_name": "dev1"})
+        result = db.get_schema_name(1)
+        assert result == "dev1"
+
+    def test_raises_tenant_not_found(self) -> None:
+        db = Database()
+        db._conn = _make_mock_db(fetchone_return=None)
+        with pytest.raises(TenantNotFoundError):
+            db.get_schema_name(99)
+
+    def test_raises_database_error_on_psycopg(self) -> None:
+        import psycopg
+
+        db = Database()
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_cur.__enter__ = MagicMock(return_value=mock_cur)
+        mock_cur.__exit__ = MagicMock(return_value=False)
+        mock_cur.execute.side_effect = psycopg.OperationalError("conn error")
+        mock_conn.cursor.return_value = mock_cur
+        db._conn = mock_conn
+        with pytest.raises(DatabaseError):
+            db.get_schema_name(1)
+
+
+# ---------------------------------------------------------------------------
+# Database.has_permission
+# ---------------------------------------------------------------------------
+
+
+class TestHasPermission:
+    def test_returns_true_when_row_found(self) -> None:
+        db = Database()
+        db._conn = _make_mock_db(fetchone_return={"1": 1})
+        assert db.has_permission("sub-abc", 1, "upload:write") is True
+
+    def test_returns_false_when_no_row(self) -> None:
+        db = Database()
+        db._conn = _make_mock_db(fetchone_return=None)
+        assert db.has_permission("sub-abc", 1, "upload:write") is False
+
+    def test_raises_database_error_on_psycopg(self) -> None:
+        import psycopg
+
+        db = Database()
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_cur.__enter__ = MagicMock(return_value=mock_cur)
+        mock_cur.__exit__ = MagicMock(return_value=False)
+        mock_cur.execute.side_effect = psycopg.OperationalError("err")
+        mock_conn.cursor.return_value = mock_cur
+        db._conn = mock_conn
+        with pytest.raises(DatabaseError):
+            db.has_permission("sub", 1, "upload:write")
+
+
+# ---------------------------------------------------------------------------
+# Database.find_existing_device_keys
+# ---------------------------------------------------------------------------
+
+
+class TestFindExistingDeviceKeys:
+    def test_returns_empty_when_no_rows(self) -> None:
+        db = Database()
+        db._conn = _make_mock_db(fetchall_return=[])
+        result = db.find_existing_device_keys(["SN001"], ["UDID001"], "dev1")
+        assert result == ExistingDeviceKeys(serials=set(), udids=set())
+
+    def test_returns_matching_serial(self) -> None:
+        db = Database()
+        db._conn = _make_mock_db(fetchall_return=[{"serial_number": "SN001", "udid": "UDID-OTHER"}])
+        result = db.find_existing_device_keys(["SN001"], ["UDID001"], "dev1")
+        assert "SN001" in result.serials
+        assert "UDID-OTHER" in result.udids
+
+    def test_returns_matching_udid(self) -> None:
+        db = Database()
+        db._conn = _make_mock_db(fetchall_return=[{"serial_number": "SN-OTHER", "udid": "UDID001"}])
+        result = db.find_existing_device_keys(["SN999"], ["UDID001"], "dev1")
+        assert "UDID001" in result.udids
+
+    def test_multiple_conflicts(self) -> None:
+        db = Database()
+        db._conn = _make_mock_db(
+            fetchall_return=[
+                {"serial_number": "SN001", "udid": "UDID001"},
+                {"serial_number": "SN002", "udid": "UDID002"},
+            ]
+        )
+        result = db.find_existing_device_keys(["SN001", "SN002"], ["UDID001", "UDID002"], "dev1")
+        assert result.serials == {"SN001", "SN002"}
+        assert result.udids == {"UDID001", "UDID002"}
+
+    def test_empty_inputs_skip_query(self) -> None:
+        """Empty serials + udids returns empty sets without touching DB."""
+        db = Database()
+        mock_conn = MagicMock()
+        db._conn = mock_conn
+        result = db.find_existing_device_keys([], [], "dev1")
+        assert result == ExistingDeviceKeys(serials=set(), udids=set())
+        mock_conn.cursor.assert_not_called()
+
+    def test_handles_none_values_in_row(self) -> None:
+        """Row with NULL columns should not add None to sets."""
+        db = Database()
+        db._conn = _make_mock_db(fetchall_return=[{"serial_number": None, "udid": None}])
+        result = db.find_existing_device_keys(["SN001"], ["UDID001"], "dev1")
+        assert result.serials == set()
+        assert result.udids == set()
+
+    def test_invalid_schema_raises(self) -> None:
+        db = Database()
+        db._conn = MagicMock()
+        with pytest.raises(DatabaseError, match="invalid schema_name"):
+            db.find_existing_device_keys(["SN001"], ["U1"], "INVALID")
+
+    def test_raises_database_error_on_psycopg(self) -> None:
+        import psycopg
+
+        db = Database()
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_cur.__enter__ = MagicMock(return_value=mock_cur)
+        mock_cur.__exit__ = MagicMock(return_value=False)
+        mock_cur.execute.side_effect = psycopg.OperationalError("err")
+        mock_conn.cursor.return_value = mock_cur
+        db._conn = mock_conn
+        with pytest.raises(DatabaseError):
+            db.find_existing_device_keys(["SN001"], ["UDID001"], "dev1")
+
+    def test_empty_serials_uses_sentinel(self) -> None:
+        """When serials is empty but udids is not, query is still executed with sentinel."""
+        db = Database()
+        db._conn = _make_mock_db(fetchall_return=[])
+        # Should not raise — sentinel prevents empty array in ANY()
+        result = db.find_existing_device_keys([], ["UDID001"], "dev1")
+        assert result == ExistingDeviceKeys(serials=set(), udids=set())
+
+    def test_empty_udids_uses_sentinel(self) -> None:
+        """When udids is empty but serials is not, query is still executed with sentinel."""
+        db = Database()
+        db._conn = _make_mock_db(fetchall_return=[])
+        result = db.find_existing_device_keys(["SN001"], [], "dev1")
+        assert result == ExistingDeviceKeys(serials=set(), udids=set())
+
+
+# ---------------------------------------------------------------------------
+# Database context manager
+# ---------------------------------------------------------------------------
+
+
+class TestDatabaseContextManager:
+    def test_require_conn_raises_outside_context(self) -> None:
+        db = Database()
+        with pytest.raises(DatabaseError, match="outside context manager"):
+            db._require_conn()
+
+    def test_connect_failure_raises_database_error(self) -> None:
+        import psycopg
+
+        with patch("db.psycopg.connect", side_effect=psycopg.OperationalError("no server")):
+            with pytest.raises(DatabaseError, match="database connection failed"):
+                with Database():
+                    pass

--- a/fluxion-backend/modules/upload_resolver/tests/test_handler.py
+++ b/fluxion-backend/modules/upload_resolver/tests/test_handler.py
@@ -1,0 +1,393 @@
+"""Unit tests for upload_resolver handler.py.
+
+All DB and SQS calls are mocked. Tests verify the full dispatch flow:
+  - Permission enforcement
+  - Per-device validation (MISSING_FIELD)
+  - Request-level dedupe (DUPLICATE_IN_REQUEST)
+  - DB dedupe (DUPLICATE_EXISTING_SERIAL / UDID)
+  - SQS fire-and-forget (failure logged, not re-raised)
+  - Aggregate counts
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import sqs as sqs_module
+from db import Database, ExistingDeviceKeys
+from handler import lambda_handler
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_event(devices: list[dict[str, Any]], *, authed: bool = True) -> dict[str, Any]:
+    """Build a minimal AppSync Lambda event for uploadDevices."""
+    return {
+        "info": {"fieldName": "uploadDevices"},
+        "arguments": {"devices": devices},
+        "identity": {
+            "claims": {
+                "sub": "user-sub-001",
+                "custom:tenant_id": "1",
+            }
+        }
+        if authed
+        else {},
+    }
+
+
+def _make_auth_db(has_perm: bool = True) -> MagicMock:
+    """Mock Database for auth (get_schema_name + has_permission)."""
+    db = MagicMock(spec=Database)
+    db.__enter__ = MagicMock(return_value=db)
+    db.__exit__ = MagicMock(return_value=False)
+    db.get_schema_name.return_value = "dev1"
+    db.has_permission.return_value = has_perm
+    return db
+
+
+def _make_upload_db(
+    existing_serials: set[str] | None = None,
+    existing_udids: set[str] | None = None,
+) -> MagicMock:
+    """Mock Database for find_existing_device_keys."""
+    db = MagicMock(spec=Database)
+    db.__enter__ = MagicMock(return_value=db)
+    db.__exit__ = MagicMock(return_value=False)
+    db.find_existing_device_keys.return_value = ExistingDeviceKeys(
+        serials=existing_serials or set(),
+        udids=existing_udids or set(),
+    )
+    return db
+
+
+def _make_sqs_client(message_id: str = "msg-001") -> MagicMock:
+    client = MagicMock()
+    client.send_message.return_value = {"MessageId": message_id}
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+class TestUploadDevicesHappy:
+    def test_three_devices_no_dupes(self) -> None:
+        """3 clean devices → accepted=3, rejected=0, errors=[]."""
+        devices = [{"serialNumber": f"SN00{i}", "udid": f"UDID00{i}"} for i in range(3)]
+        auth_db = _make_auth_db()
+        upload_db = _make_upload_db()
+        sqs_client = _make_sqs_client()
+
+        with (
+            patch("auth.Database", return_value=auth_db),
+            patch("handler.Database", return_value=upload_db),
+            patch.object(sqs_module, "_get_client", return_value=sqs_client),
+        ):
+            result = lambda_handler(_make_event(devices), MagicMock(aws_request_id="req-1"))
+
+        assert result["totalRequested"] == 3
+        assert result["accepted"] == 3
+        assert result["rejected"] == 0
+        assert result["errors"] == []
+
+    def test_empty_devices_returns_zero_counts(self) -> None:
+        """Empty input → {totalRequested:0, accepted:0, rejected:0, errors:[]}."""
+        auth_db = _make_auth_db()
+        with (
+            patch("auth.Database", return_value=auth_db),
+        ):
+            result = lambda_handler(_make_event([]), MagicMock(aws_request_id="req-empty"))
+
+        assert result["totalRequested"] == 0
+        assert result["accepted"] == 0
+        assert result["rejected"] == 0
+        assert result["errors"] == []
+
+    def test_optional_fields_passed_to_sqs(self) -> None:
+        """name, model, osVersion are forwarded in SQS payload."""
+        device = {
+            "serialNumber": "SN-A",
+            "udid": "UDID-A",
+            "name": "My Device",
+            "model": "iPhone 15",
+            "osVersion": "17.0",
+        }
+        auth_db = _make_auth_db()
+        upload_db = _make_upload_db()
+        sqs_client = _make_sqs_client()
+
+        with (
+            patch("auth.Database", return_value=auth_db),
+            patch("handler.Database", return_value=upload_db),
+            patch.object(sqs_module, "_get_client", return_value=sqs_client),
+        ):
+            lambda_handler(_make_event([device]), MagicMock(aws_request_id="req-opt"))
+
+        import json
+
+        sent = json.loads(sqs_client.send_message.call_args[1]["MessageBody"])
+        assert sent["name"] == "My Device"
+        assert sent["model"] == "iPhone 15"
+        assert sent["osVersion"] == "17.0"
+
+
+# ---------------------------------------------------------------------------
+# Permission enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestPermissionEnforcement:
+    def test_forbidden_when_no_permission(self) -> None:
+        auth_db = _make_auth_db(has_perm=False)
+        with patch("auth.Database", return_value=auth_db):
+            result = lambda_handler(
+                _make_event([{"serialNumber": "SN1", "udid": "U1"}]),
+                MagicMock(aws_request_id="req-forbidden"),
+            )
+        assert result["errorType"] == "FORBIDDEN"
+
+    def test_unauthenticated_when_identity_missing(self) -> None:
+        event = {
+            "info": {"fieldName": "uploadDevices"},
+            "arguments": {"devices": []},
+            "identity": {},
+        }
+        result = lambda_handler(event, MagicMock(aws_request_id="req-unauth"))
+        assert result["errorType"] == "UNAUTHENTICATED"
+
+
+# ---------------------------------------------------------------------------
+# MISSING_FIELD validation
+# ---------------------------------------------------------------------------
+
+
+class TestMissingField:
+    def test_empty_serial_number(self) -> None:
+        auth_db = _make_auth_db()
+        with patch("auth.Database", return_value=auth_db):
+            result = lambda_handler(
+                _make_event([{"serialNumber": "", "udid": "UDID-1"}]),
+                MagicMock(aws_request_id="req-msn"),
+            )
+        assert result["rejected"] == 1
+        assert result["accepted"] == 0
+        err = result["errors"][0]
+        assert err["index"] == 0
+        assert "MISSING_FIELD" in err["reason"]
+        assert err["serialNumber"] is None
+
+    def test_empty_udid(self) -> None:
+        auth_db = _make_auth_db()
+        with patch("auth.Database", return_value=auth_db):
+            result = lambda_handler(
+                _make_event([{"serialNumber": "SN-1", "udid": ""}]),
+                MagicMock(aws_request_id="req-mudid"),
+            )
+        assert result["rejected"] == 1
+        err = result["errors"][0]
+        assert "MISSING_FIELD" in err["reason"]
+        assert err["serialNumber"] == "SN-1"
+
+    def test_index_preserved_for_middle_device(self) -> None:
+        """Device at index 1 has empty serial — error.index == 1."""
+        devices = [
+            {"serialNumber": "SN-0", "udid": "UDID-0"},
+            {"serialNumber": "", "udid": "UDID-1"},
+            {"serialNumber": "SN-2", "udid": "UDID-2"},
+        ]
+        auth_db = _make_auth_db()
+        upload_db = _make_upload_db()
+        sqs_client = _make_sqs_client()
+
+        with (
+            patch("auth.Database", return_value=auth_db),
+            patch("handler.Database", return_value=upload_db),
+            patch.object(sqs_module, "_get_client", return_value=sqs_client),
+        ):
+            result = lambda_handler(_make_event(devices), MagicMock(aws_request_id="req-idx"))
+
+        assert result["rejected"] == 1
+        assert result["accepted"] == 2
+        assert result["errors"][0]["index"] == 1
+
+
+# ---------------------------------------------------------------------------
+# DUPLICATE_IN_REQUEST
+# ---------------------------------------------------------------------------
+
+
+class TestDuplicateInRequest:
+    def test_duplicate_serial_in_request(self) -> None:
+        devices = [
+            {"serialNumber": "SN-DUP", "udid": "UDID-A"},
+            {"serialNumber": "SN-DUP", "udid": "UDID-B"},
+        ]
+        auth_db = _make_auth_db()
+        upload_db = _make_upload_db()
+        sqs_client = _make_sqs_client()
+
+        with (
+            patch("auth.Database", return_value=auth_db),
+            patch("handler.Database", return_value=upload_db),
+            patch.object(sqs_module, "_get_client", return_value=sqs_client),
+        ):
+            result = lambda_handler(_make_event(devices), MagicMock(aws_request_id="req-dup-sn"))
+
+        assert result["accepted"] == 1
+        assert result["rejected"] == 1
+        err = result["errors"][0]
+        assert err["index"] == 1
+        assert "DUPLICATE_IN_REQUEST" in err["reason"]
+
+    def test_duplicate_udid_in_request(self) -> None:
+        devices = [
+            {"serialNumber": "SN-A", "udid": "UDID-DUP"},
+            {"serialNumber": "SN-B", "udid": "UDID-DUP"},
+        ]
+        auth_db = _make_auth_db()
+        upload_db = _make_upload_db()
+        sqs_client = _make_sqs_client()
+
+        with (
+            patch("auth.Database", return_value=auth_db),
+            patch("handler.Database", return_value=upload_db),
+            patch.object(sqs_module, "_get_client", return_value=sqs_client),
+        ):
+            result = lambda_handler(_make_event(devices), MagicMock(aws_request_id="req-dup-ud"))
+
+        assert result["rejected"] == 1
+        err = result["errors"][0]
+        assert "DUPLICATE_IN_REQUEST" in err["reason"]
+        assert err["index"] == 1
+
+
+# ---------------------------------------------------------------------------
+# DUPLICATE_EXISTING_SERIAL / UDID
+# ---------------------------------------------------------------------------
+
+
+class TestDuplicateExisting:
+    def test_duplicate_existing_serial(self) -> None:
+        devices = [
+            {"serialNumber": "SN-EXISTS", "udid": "UDID-NEW"},
+        ]
+        auth_db = _make_auth_db()
+        upload_db = _make_upload_db(existing_serials={"SN-EXISTS"})
+
+        with (
+            patch("auth.Database", return_value=auth_db),
+            patch("handler.Database", return_value=upload_db),
+        ):
+            result = lambda_handler(_make_event(devices), MagicMock(aws_request_id="req-ex-sn"))
+
+        assert result["accepted"] == 0
+        assert result["rejected"] == 1
+        err = result["errors"][0]
+        assert "DUPLICATE_EXISTING_SERIAL" in err["reason"]
+        assert err["index"] == 0
+
+    def test_duplicate_existing_udid(self) -> None:
+        devices = [
+            {"serialNumber": "SN-NEW", "udid": "UDID-EXISTS"},
+        ]
+        auth_db = _make_auth_db()
+        upload_db = _make_upload_db(existing_udids={"UDID-EXISTS"})
+
+        with (
+            patch("auth.Database", return_value=auth_db),
+            patch("handler.Database", return_value=upload_db),
+        ):
+            result = lambda_handler(_make_event(devices), MagicMock(aws_request_id="req-ex-ud"))
+
+        assert result["accepted"] == 0
+        assert result["rejected"] == 1
+        err = result["errors"][0]
+        assert "DUPLICATE_EXISTING_UDID" in err["reason"]
+
+    def test_mixed_accepted_and_rejected(self) -> None:
+        """3 devices: 1 request-dupe + 1 existing + 1 accepted."""
+        devices = [
+            {"serialNumber": "SN-OK", "udid": "UDID-OK"},
+            {"serialNumber": "SN-DUP", "udid": "UDID-B"},
+            {"serialNumber": "SN-DUP", "udid": "UDID-C"},  # request-dupe
+        ]
+        auth_db = _make_auth_db()
+        # SN-OK passes DB check (not in existing)
+        upload_db = _make_upload_db(existing_serials=set(), existing_udids=set())
+        sqs_client = _make_sqs_client()
+
+        with (
+            patch("auth.Database", return_value=auth_db),
+            patch("handler.Database", return_value=upload_db),
+            patch.object(sqs_module, "_get_client", return_value=sqs_client),
+        ):
+            result = lambda_handler(_make_event(devices), MagicMock(aws_request_id="req-mix"))
+
+        assert result["totalRequested"] == 3
+        assert result["accepted"] == 2  # SN-OK and SN-DUP first occurrence
+        assert result["rejected"] == 1  # third device (index 2)
+        assert result["errors"][0]["index"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Oversize input
+# ---------------------------------------------------------------------------
+
+
+class TestOversizeInput:
+    def test_oversize_raises_invalid_input(self) -> None:
+        """1001 devices triggers Pydantic cap → INVALID_INPUT error."""
+        devices = [{"serialNumber": f"SN{i:04d}", "udid": f"UID{i:04d}"} for i in range(1001)]
+        auth_db = _make_auth_db()
+        with patch("auth.Database", return_value=auth_db):
+            result = lambda_handler(_make_event(devices), MagicMock(aws_request_id="req-big"))
+        assert result["errorType"] == "INVALID_INPUT"
+        assert "1000" in result["errorMessage"]
+
+
+# ---------------------------------------------------------------------------
+# SQS fire-and-forget
+# ---------------------------------------------------------------------------
+
+
+class TestSqsFireAndForget:
+    def test_sqs_failure_does_not_fail_request(self) -> None:
+        """SQS error after dedupe → device still counted as accepted, no error returned."""
+        from exceptions import SqsError
+
+        devices = [{"serialNumber": "SN-SQS", "udid": "UDID-SQS"}]
+        auth_db = _make_auth_db()
+        upload_db = _make_upload_db()
+
+        with (
+            patch("auth.Database", return_value=auth_db),
+            patch("handler.Database", return_value=upload_db),
+            patch("handler.enqueue_upload", side_effect=SqsError("queue error")),
+        ):
+            result = lambda_handler(_make_event(devices), MagicMock(aws_request_id="req-sqsf"))
+
+        # SQS failure is silent — device still counted as accepted.
+        assert result["accepted"] == 1
+        assert result["rejected"] == 0
+        assert result["errors"] == []
+
+
+# ---------------------------------------------------------------------------
+# Unknown field
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownField:
+    def test_unknown_field_returns_error(self) -> None:
+        event = {
+            "info": {"fieldName": "nonExistentField"},
+            "arguments": {},
+            "identity": {},
+        }
+        result = lambda_handler(event, MagicMock(aws_request_id="req-unk"))
+        assert result["errorType"] == "UNKNOWN_FIELD"

--- a/fluxion-backend/modules/upload_resolver/tests/test_sqs.py
+++ b/fluxion-backend/modules/upload_resolver/tests/test_sqs.py
@@ -1,0 +1,102 @@
+"""Unit tests for upload_resolver sqs.py.
+
+All tests patch sqs._get_client to avoid real boto3 calls.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import sqs as sqs_module
+from exceptions import SqsError
+from sqs import enqueue_upload
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_sqs_client(message_id: str = "msg-001") -> MagicMock:
+    client = MagicMock()
+    client.send_message.return_value = {"MessageId": message_id}
+    return client
+
+
+# ---------------------------------------------------------------------------
+# enqueue_upload — happy path
+# ---------------------------------------------------------------------------
+
+
+class TestEnqueueUpload:
+    def test_happy_path_returns_message_id(self) -> None:
+        client = _make_sqs_client("msg-xyz")
+        with patch.object(sqs_module, "_get_client", return_value=client):
+            result = enqueue_upload(
+                {"tenant_schema": "dev1", "serialNumber": "SN001", "udid": "U001"},
+                queue_url="https://sqs.us-east-1.amazonaws.com/000/test",
+            )
+        assert result == "msg-xyz"
+
+    def test_uses_env_queue_url_when_not_provided(self) -> None:
+        client = _make_sqs_client("msg-env")
+        with patch.object(sqs_module, "_get_client", return_value=client):
+            result = enqueue_upload({"serialNumber": "SN001", "udid": "U001"})
+        assert result == "msg-env"
+        call_kwargs = client.send_message.call_args[1]
+        # Uses the default from UPLOAD_PROCESSOR_QUEUE_URL env (set in conftest).
+        assert "QueueUrl" in call_kwargs
+
+    def test_message_body_is_json_serialized(self) -> None:
+        client = _make_sqs_client()
+        payload = {"tenant_schema": "dev1", "serialNumber": "SN001", "udid": "U001", "name": None}
+        with patch.object(sqs_module, "_get_client", return_value=client):
+            enqueue_upload(payload, queue_url="https://sqs.test/queue")
+        import json
+
+        sent_body = client.send_message.call_args[1]["MessageBody"]
+        assert json.loads(sent_body) == payload
+
+    def test_client_error_raises_sqs_error(self) -> None:
+        """boto3 ClientError must be converted to SqsError."""
+        from botocore.exceptions import ClientError
+
+        client = MagicMock()
+        client.send_message.side_effect = ClientError(
+            {"Error": {"Code": "AccessDenied", "Message": "denied"}}, "SendMessage"
+        )
+        with patch.object(sqs_module, "_get_client", return_value=client):
+            with pytest.raises(SqsError, match="SQS send_message failed"):
+                enqueue_upload({"serialNumber": "SN1"}, queue_url="https://sqs.test/q")
+
+    def test_unexpected_error_raises_sqs_error(self) -> None:
+        """Non-ClientError exceptions are also wrapped in SqsError."""
+        client = MagicMock()
+        client.send_message.side_effect = RuntimeError("network failure")
+        with patch.object(sqs_module, "_get_client", return_value=client):
+            with pytest.raises(SqsError, match="unexpected error"):
+                enqueue_upload({"serialNumber": "SN1"}, queue_url="https://sqs.test/q")
+
+
+# ---------------------------------------------------------------------------
+# _get_client — lazy singleton
+# ---------------------------------------------------------------------------
+
+
+class TestGetClient:
+    def test_singleton_reused(self) -> None:
+        """_get_client returns same instance on second call."""
+        sqs_module._client = None  # reset
+        mock_boto3 = MagicMock()
+        fake_client = MagicMock()
+        mock_boto3.client.return_value = fake_client
+        with patch.dict("sys.modules", {"boto3": mock_boto3}):
+            import importlib
+
+            importlib.reload(sqs_module)
+            c1 = sqs_module._get_client()
+            c2 = sqs_module._get_client()
+        assert c1 is c2
+        # Reset for other tests.
+        sqs_module._client = None

--- a/fluxion-backend/terraform/envs/dev/main.tf
+++ b/fluxion-backend/terraform/envs/dev/main.tf
@@ -87,7 +87,7 @@ module "resolver_user" {
   }
   extra_policy_statements = [
     {
-      effect  = "Allow"
+      effect = "Allow"
       actions = [
         "cognito-idp:AdminCreateUser",
         "cognito-idp:AdminDeleteUser",
@@ -95,6 +95,56 @@ module "resolver_user" {
         "cognito-idp:AdminUpdateUserAttributes",
       ]
       resources = [module.auth.user_pool_arn]
+    },
+  ]
+}
+
+module "resolver_action" {
+  source        = "../../modules/lambda_function"
+  function_name = "${var.resource_name_prefix}-action-resolver"
+  image_uri     = "${module.ecr.repository_urls["action_resolver"]}:latest"
+  env = {
+    DATABASE_URI             = local.database_uri
+    POWERTOOLS_SERVICE_NAME  = "action_resolver"
+    ACTION_TRIGGER_QUEUE_URL = aws_sqs_queue.action_trigger.url
+    UPLOADS_BUCKET           = aws_s3_bucket.uploads.id
+  }
+  vpc_config = {
+    subnet_ids = module.network.private_subnet_ids
+    sg_id      = module.network.lambda_sg_id
+  }
+  extra_policy_statements = [
+    {
+      effect    = "Allow"
+      actions   = ["sqs:SendMessage"]
+      resources = [aws_sqs_queue.action_trigger.arn]
+    },
+    {
+      effect    = "Allow"
+      actions   = ["s3:PutObject", "s3:GetObject"]
+      resources = ["${aws_s3_bucket.uploads.arn}/action-log-errors/*"]
+    },
+  ]
+}
+
+module "resolver_upload" {
+  source        = "../../modules/lambda_function"
+  function_name = "${var.resource_name_prefix}-upload-resolver"
+  image_uri     = "${module.ecr.repository_urls["upload_resolver"]}:latest"
+  env = {
+    DATABASE_URI               = local.database_uri
+    POWERTOOLS_SERVICE_NAME    = "upload_resolver"
+    UPLOAD_PROCESSOR_QUEUE_URL = aws_sqs_queue.upload_processor.url
+  }
+  vpc_config = {
+    subnet_ids = module.network.private_subnet_ids
+    sg_id      = module.network.lambda_sg_id
+  }
+  extra_policy_statements = [
+    {
+      effect    = "Allow"
+      actions   = ["sqs:SendMessage"]
+      resources = [aws_sqs_queue.upload_processor.arn]
     },
   ]
 }
@@ -110,6 +160,8 @@ module "api" {
     device   = module.resolver_device.function_arn
     platform = module.resolver_platform.function_arn
     user     = module.resolver_user.function_arn
+    action   = module.resolver_action.function_arn
+    upload   = module.resolver_upload.function_arn
   }
   log_retention_days  = 14
   log_field_log_level = "ERROR"
@@ -140,6 +192,14 @@ locals {
   # Secret JSON shape: {"username": "...", "password": "..."} (set by database module).
   _db_secret   = jsondecode(data.aws_secretsmanager_secret_version.db.secret_string)
   database_uri = "postgresql://${local._db_secret.username}:${local._db_secret.password}@${module.database.effective_endpoint}/fluxion"
+
+  # GH-35: SQS + S3 references consumed by action_resolver / upload_resolver (P3 wiring).
+  action_trigger_queue_arn   = aws_sqs_queue.action_trigger.arn
+  action_trigger_queue_url   = aws_sqs_queue.action_trigger.url
+  upload_processor_queue_arn = aws_sqs_queue.upload_processor.arn
+  upload_processor_queue_url = aws_sqs_queue.upload_processor.url
+  uploads_bucket_arn         = aws_s3_bucket.uploads.arn
+  uploads_bucket_name        = aws_s3_bucket.uploads.bucket
 }
 
 module "ecr" {
@@ -260,5 +320,151 @@ resource "aws_ssm_parameter" "appsync_lambda_invoke_role_arn" {
   name  = "${local.ssm_prefix}/api/lambda-invoke-role-arn"
   type  = "String"
   value = module.api.appsync_lambda_invoke_role_arn
+  tags  = local.ssm_tags
+}
+
+# ---------------------------------------------------------------------------
+# SQS — action-trigger queue + DLQ (GH-35)
+# ---------------------------------------------------------------------------
+
+resource "aws_sqs_queue" "action_trigger_dlq" {
+  name                      = "${var.resource_name_prefix}-action-trigger-dlq"
+  message_retention_seconds = 1209600 # 14 days for DLQ visibility
+  tags                      = local.ssm_tags
+}
+
+resource "aws_sqs_queue" "action_trigger" {
+  name                       = "${var.resource_name_prefix}-action-trigger-sqs"
+  visibility_timeout_seconds = 30
+  message_retention_seconds  = 345600 # 4 days
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.action_trigger_dlq.arn
+    maxReceiveCount     = 5
+  })
+
+  tags = local.ssm_tags
+}
+
+# ---------------------------------------------------------------------------
+# SQS — upload-processor queue + DLQ (GH-35)
+# ---------------------------------------------------------------------------
+
+resource "aws_sqs_queue" "upload_processor_dlq" {
+  name                      = "${var.resource_name_prefix}-upload-processor-dlq"
+  message_retention_seconds = 1209600 # 14 days for DLQ visibility
+  tags                      = local.ssm_tags
+}
+
+resource "aws_sqs_queue" "upload_processor" {
+  name                       = "${var.resource_name_prefix}-upload-processor-sqs"
+  visibility_timeout_seconds = 30
+  message_retention_seconds  = 345600 # 4 days
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.upload_processor_dlq.arn
+    maxReceiveCount     = 5
+  })
+
+  tags = local.ssm_tags
+}
+
+# ---------------------------------------------------------------------------
+# S3 — uploads bucket (GH-35)
+# ---------------------------------------------------------------------------
+
+resource "aws_s3_bucket" "uploads" {
+  bucket = "${var.resource_name_prefix}-uploads"
+  tags   = local.ssm_tags
+}
+
+resource "aws_s3_bucket_versioning" "uploads" {
+  bucket = aws_s3_bucket.uploads.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "uploads" {
+  bucket = aws_s3_bucket.uploads.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "uploads" {
+  bucket = aws_s3_bucket.uploads.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_ownership_controls" "uploads" {
+  bucket = aws_s3_bucket.uploads.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "uploads" {
+  bucket = aws_s3_bucket.uploads.id
+
+  rule {
+    id     = "expire-action-log-errors"
+    status = "Enabled"
+
+    filter {
+      prefix = "action-log-errors/"
+    }
+
+    expiration {
+      days = 30
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------
+# SSM — SQS + S3 ARNs/URLs for downstream Lambdas (GH-35)
+# ---------------------------------------------------------------------------
+
+resource "aws_ssm_parameter" "sqs_action_trigger_arn" {
+  name  = "${local.ssm_prefix}/sqs/action-trigger-arn"
+  type  = "String"
+  value = aws_sqs_queue.action_trigger.arn
+  tags  = local.ssm_tags
+}
+
+resource "aws_ssm_parameter" "sqs_action_trigger_url" {
+  name  = "${local.ssm_prefix}/sqs/action-trigger-url"
+  type  = "String"
+  value = aws_sqs_queue.action_trigger.url
+  tags  = local.ssm_tags
+}
+
+resource "aws_ssm_parameter" "sqs_upload_processor_arn" {
+  name  = "${local.ssm_prefix}/sqs/upload-processor-arn"
+  type  = "String"
+  value = aws_sqs_queue.upload_processor.arn
+  tags  = local.ssm_tags
+}
+
+resource "aws_ssm_parameter" "sqs_upload_processor_url" {
+  name  = "${local.ssm_prefix}/sqs/upload-processor-url"
+  type  = "String"
+  value = aws_sqs_queue.upload_processor.url
+  tags  = local.ssm_tags
+}
+
+resource "aws_ssm_parameter" "s3_uploads_bucket_name" {
+  name  = "${local.ssm_prefix}/s3/uploads-bucket-name"
+  type  = "String"
+  value = aws_s3_bucket.uploads.bucket
   tags  = local.ssm_tags
 }

--- a/fluxion-backend/terraform/modules/api/README.md
+++ b/fluxion-backend/terraform/modules/api/README.md
@@ -23,9 +23,8 @@ AWS AppSync GraphQL API fronting the Fluxion backend. Ticket [#33](https://githu
 | `platform` | platform-resolver | `listStates`/`listPolicies`/`listActions`/`listServices`; `updateState`/`updatePolicy`/`updateAction`/`updateService` |
 | `message_template` | message-template-resolver | `getMessageTemplate`, `listMessageTemplates`; `generateIconUploadUrl`, `createMessageTemplate`, `updateMessageTemplate`, `deleteMessageTemplate` |
 | `tac` | tac-resolver | `getTAC`, `listTACs`; `createTAC`, `updateTAC`, `deleteTAC` |
-| `action_log` | action-log-resolver | `getActionLog`, `listActionLogs`; `generateActionLogErrorReport` |
 | `user` | user-resolver | `getUser`, `listUsers`, `getCurrentUser`; `createUser`, `updateUser` |
-| `action` | action-resolver | `assignAction`, `assignBulkAction` |
+| `action` | action-resolver | `assignAction`, `assignBulkAction`; `getActionLog`, `listActionLogs`, `generateActionLogErrorReport` |
 | `upload` | upload-resolver | `uploadDevices` |
 | `chat` | chat-resolver | `getChatSession`, `listChatSessions`; `sendChatMessage` |
 

--- a/fluxion-backend/terraform/modules/api/locals.tf
+++ b/fluxion-backend/terraform/modules/api/locals.tf
@@ -23,17 +23,13 @@ locals {
       Query    = ["getTAC", "listTACs"]
       Mutation = ["createTAC", "updateTAC", "deleteTAC"]
     }
-    action_log = {
-      Query    = ["getActionLog", "listActionLogs"]
-      Mutation = ["generateActionLogErrorReport"]
-    }
     user = {
       Query    = ["getUser", "listUsers", "getCurrentUser"]
       Mutation = ["createUser", "updateUser"]
     }
     action = {
-      Query    = []
-      Mutation = ["assignAction", "assignBulkAction"]
+      Query    = ["getActionLog", "listActionLogs"]
+      Mutation = ["assignAction", "assignBulkAction", "generateActionLogErrorReport"]
     }
     upload = {
       Query    = []

--- a/fluxion-backend/terraform/modules/api/variables.tf
+++ b/fluxion-backend/terraform/modules/api/variables.tf
@@ -29,7 +29,7 @@ variable "lambda_resolver_arns" {
   description = <<-EOT
     Map of resolver key → Lambda function ARN. Keys:
     device | platform | user | action | upload | chat |
-    tac | message_template | action_log.
+    tac | message_template.
 
     Empty map = deploy AppSync API + schema + internal NONE
     data source only; skip all Lambda-backed data sources and

--- a/fluxion-backend/uv.lock
+++ b/fluxion-backend/uv.lock
@@ -4,11 +4,32 @@ requires-python = ">=3.12"
 
 [manifest]
 members = [
+    "action-resolver",
     "device-resolver",
     "fluxion-backend",
     "lambda-template",
     "platform-resolver",
+    "upload-resolver",
     "user-resolver",
+]
+
+[[package]]
+name = "action-resolver"
+version = "0.1.0"
+source = { virtual = "modules/action_resolver" }
+dependencies = [
+    { name = "aws-lambda-powertools" },
+    { name = "boto3" },
+    { name = "psycopg", extra = ["binary"] },
+    { name = "pydantic" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aws-lambda-powertools", specifier = ">=2.30" },
+    { name = "boto3", specifier = ">=1.34" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.1,<4" },
+    { name = "pydantic", specifier = ">=2.6" },
 ]
 
 [[package]]
@@ -1803,6 +1824,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/f5/cd531b2d15a671a40c0f66cf06bc3570a12cd56eef98960068ebbad1bf5a/tzdata-2026.1.tar.gz", hash = "sha256:67658a1903c75917309e753fdc349ac0efd8c27db7a0cb406a25be4840f87f98", size = 197639, upload-time = "2026-04-03T11:25:22.002Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/70/d460bd685a170790ec89317e9bd33047988e4bce507b831f5db771e142de/tzdata-2026.1-py2.py3-none-any.whl", hash = "sha256:4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9", size = 348952, upload-time = "2026-04-03T11:25:20.313Z" },
+]
+
+[[package]]
+name = "upload-resolver"
+version = "0.1.0"
+source = { virtual = "modules/upload_resolver" }
+dependencies = [
+    { name = "aws-lambda-powertools" },
+    { name = "boto3" },
+    { name = "psycopg", extra = ["binary"] },
+    { name = "pydantic" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aws-lambda-powertools", specifier = ">=2.30" },
+    { name = "boto3", specifier = ">=1.34" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.1,<4" },
+    { name = "pydantic", specifier = ">=2.6" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #35.

Two new Lambda resolvers extending the #34 pattern + the prep infra they need.

## What ships

**action_resolver** (5 fields):
- `assignAction(input) → AssignActionResult` — single device assignment with FSM guards (busy / valid-transition) + optional `messageTemplateId`
- `assignBulkAction(input) → AssignBulkActionResult` — race-safe bulk assignment via `UPDATE … WHERE assigned_action_id IS NULL RETURNING id` (only RETURNED ids commit; rest land in `failed[]`)
- `getActionLog(batchId) → ActionLog` — read projection over `batch_actions` + computed `errorCount`
- `listActionLogs(limit, nextToken) → ActionLogConnection` — tuple-cursor pagination (created_at, id) for tie stability
- `generateActionLogErrorReport(batchId) → ActionLogErrorReport` — CSV (UTF-8+BOM, header) → S3 → 5-min presigned GET URL

**upload_resolver** (1 field):
- `uploadDevices(devices) → UploadResult` — validate {serialNumber, udid required, batch-level dedupe} → enqueue to SQS

**Prep infra (P0):**
- 2 Alembic migrations: 3 new permission codes (`action:execute`, `actionlog:read`, `upload:write`) + dev admin grants in tenant dev1
- 2 SQS queues + DLQs: `fluxion-dev-action-trigger-sqs`, `fluxion-dev-upload-processor-sqs` (maxReceiveCount=5)
- S3 bucket `fluxion-dev-uploads` (AES256 + lifecycle 30d on `action-log-errors/*` + BlockPublicAccess)
- 5 SSM params for downstream Lambda env vars

**Wiring (P3):**
- `terraform/modules/api/locals.tf` — `action_log` resolver key folded into `action`
- `envs/dev/main.tf` — `module \"resolver_action\"` + `module \"resolver_upload\"` + extended `lambda_resolver_arns`

## Locked architectural decisions

1. Mutation names: `assignAction` / `assignBulkAction` (matches schema.graphql; issue's `executeAction` was loose)
2. `action_log` resolver key folded into `action` — single Lambda owns 5 action-domain fields
3. `ActionLog.id` exposed = `batch_actions.id` (PK); `batch_actions.batch_id` (UUID) stays as separate `ActionLog.batchId` field
4. SQS + S3 inline in envs/dev/main.tf (no new TF modules until staging/prod)
5. Per-resolver thin AWS wrappers (`sqs.py` / `s3.py`); no shared messaging lib
6. FSM validation = SQL queries (DB-driven FSM, no Python state machine)
7. `errorCount` computed via FILTER subquery, not stored
8. CSV: UTF-8 + BOM, header, columns `[device_id, error_code, error_message, finished_at]`
9. SQS envelope: `{batchId, deviceId, actionId, executionId, commandUuid, configuration, messageContent, tenant_schema}`
10. S3 lifecycle: 30-day expiration on `action-log-errors/*`

## Tests

| Module | Tests | Coverage |
|---|---|---|
| action_resolver | 106 | 94.87% |
| upload_resolver | 47 | 95.78% |

ruff + mypy --strict + terraform validate all clean.

## Reuse from #34

Verbatim: `@permission_required` / `@validate_input` / `@validate_patch` decorators, Pydantic `dump_row` classmethods, psycopg3 `Database` (connection-only, schema per-method), self-contained Dockerfile (FROM `public.ecr.aws/lambda/python:3.12`), Lambda manifest format (`provenance: false`), AppSync `function_arn` (not `invoke_arn`).

## What's NOT in this PR

- P4 — live E2E smoke against deployed dev. Runs after merge → promotion → deploy → fresh tunnel + smoke against the new fields.

## Plan dir

`plans/260426-1549-GH-35-action-upload-resolvers/` — overview + 6 phase files + planner report.