### PR TITLE
[#35]: grant SQS + S3 lifecycle perms to gha-deploy role

### DIFF
--- a/fluxion-backend/terraform/bootstrap/oidc.tf
+++ b/fluxion-backend/terraform/bootstrap/oidc.tf
@@ -169,6 +169,70 @@ data "aws_iam_policy_document" "gha_deploy_inline" {
     resources = ["*"]
   }
 
+  # SQS queue lifecycle for backend Lambda async paths (action_resolver / upload_resolver
+  # → SQS, plus DLQs). Scoped to fluxion-* queues only.
+  statement {
+    sid    = "SQSQueueLifecycle"
+    effect = "Allow"
+    actions = [
+      "sqs:CreateQueue",
+      "sqs:DeleteQueue",
+      "sqs:GetQueueAttributes",
+      "sqs:SetQueueAttributes",
+      "sqs:GetQueueUrl",
+      "sqs:ListQueues",
+      "sqs:ListQueueTags",
+      "sqs:TagQueue",
+      "sqs:UntagQueue",
+    ]
+    resources = [
+      "arn:aws:sqs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:${var.resource_name_prefix}-*",
+    ]
+  }
+
+  # S3 application buckets (e.g. fluxion-dev-uploads for action-log error CSV reports).
+  # Tfstate bucket has its own scoped statement above.
+  statement {
+    sid    = "S3AppBuckets"
+    effect = "Allow"
+    actions = [
+      "s3:CreateBucket",
+      "s3:DeleteBucket",
+      "s3:ListBucket",
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+      "s3:GetBucketTagging",
+      "s3:PutBucketTagging",
+      "s3:GetBucketVersioning",
+      "s3:PutBucketVersioning",
+      "s3:GetBucketLifecycleConfiguration",
+      "s3:PutBucketLifecycleConfiguration",
+      "s3:DeleteBucketLifecycle",
+      "s3:GetBucketPublicAccessBlock",
+      "s3:PutBucketPublicAccessBlock",
+      "s3:GetBucketEncryption",
+      "s3:PutBucketEncryption",
+      "s3:GetBucketOwnershipControls",
+      "s3:PutBucketOwnershipControls",
+      "s3:GetBucketAcl",
+      "s3:PutBucketAcl",
+      "s3:GetBucketCORS",
+      "s3:PutBucketCORS",
+      "s3:GetBucketPolicy",
+      "s3:PutBucketPolicy",
+      "s3:DeleteBucketPolicy",
+      "s3:GetBucketLogging",
+      "s3:PutBucketLogging",
+    ]
+    resources = [
+      "arn:aws:s3:::${var.resource_name_prefix}-uploads",
+      "arn:aws:s3:::${var.resource_name_prefix}-uploads/*",
+      "arn:aws:s3:::fluxion-dev-uploads",
+      "arn:aws:s3:::fluxion-dev-uploads/*",
+    ]
+  }
+
   statement {
     sid    = "SSMParamsScoped"
     effect = "Allow"


### PR DESCRIPTION
## Why

PR #96 deploy (run 24960075105) cleared all 5 docker pushes but tf-backend full apply failed with 3 IAM \`AccessDenied\` errors:

\`\`\`
sqs:CreateQueue on fluxion-dev-action-trigger-dlq
sqs:CreateQueue on fluxion-dev-upload-processor-dlq
s3:CreateBucket on fluxion-dev-uploads
\`\`\`

\`gha-deploy\` role's inline policy never had SQS perms (no SQS infra existed before #35) and only had S3 scoped to the tfstate bucket. Same kind of gap as #74 (ecr:DeleteLifecyclePolicy).

## Fix

Two new statements in \`fluxion-backend/terraform/bootstrap/oidc.tf\`:

- **SQSQueueLifecycle** — scoped to \`{prefix}-*\` queue ARNs. Covers create/delete + tag/get/set attributes (enough for queue + DLQ + redrive_policy).
- **S3AppBuckets** — scoped to \`{prefix}-uploads\` + \`fluxion-dev-uploads\` (literal). Covers create/delete + tagging + versioning + lifecycle + public-access-block + encryption + ownership-controls (enough for the full S3 resource graph AWS provider creates).

## After merge

This is a **bootstrap-only** TF change — runs outside the Deploy workflow. Sequence:

1. Merge to develop
2. Promote develop → master (PR)
3. Manual \`terraform apply\` in \`fluxion-backend/terraform/bootstrap/\` with admin AWS credentials (per bootstrap README) to publish the new policy
4. Re-trigger Deploy on master (push or workflow_dispatch). tf-backend now has perms to create the queues + bucket.

## Risk

Bootstrap apply is rare and reversible (policy version rollback). Scope is tight: SQS = fluxion-* prefix only, S3 = literal bucket names only. No wildcards on ARN at the resource type level.