### PR TITLE
[#35]: fix AppSync request_template to send info.fieldName

### DIFF
--- a/fluxion-backend/terraform/modules/api/resolvers.tf
+++ b/fluxion-backend/terraform/modules/api/resolvers.tf
@@ -9,7 +9,12 @@ resource "aws_appsync_resolver" "unit" {
   field       = each.value.field_name
   data_source = aws_appsync_datasource.lambda[each.value.resolver].name
 
-  # Classic AppSync Lambda invocation template.
+  # Classic AppSync Lambda invocation template — uses the AWS standard
+  # event shape so Lambda dispatchers can read event["info"]["fieldName"].
+  # The original (field/typeName) shape was non-standard and the Lambda
+  # dispatchers in fluxion-backend/modules/*/src/handler.py don't read it,
+  # so every resolver silently raised UnknownFieldError. Replaced with
+  # info{} to match `aws_lambda_powertools` / standard direct-resolver shape.
   # $util.* and $ctx.* are VTL — Terraform leaves them alone because they
   # don't use the ${...} interpolation syntax.
   request_template = <<-EOT
@@ -17,8 +22,10 @@ resource "aws_appsync_resolver" "unit" {
       "version": "2018-05-29",
       "operation": "Invoke",
       "payload": {
-        "field": "${each.value.field_name}",
-        "typeName": "${each.value.type_name}",
+        "info": {
+          "fieldName": "${each.value.field_name}",
+          "parentTypeName": "${each.value.type_name}"
+        },
         "arguments": $util.toJson($ctx.args),
         "identity": $util.toJson($ctx.identity),
         "source": $util.toJson($ctx.source),


### PR DESCRIPTION
## What this fixes

P4 smoke discovered that **every resolver was silently failing** end-to-end since #33's AppSync wiring landed. Direct \`aws lambda invoke\` worked, AppSync invoke didn't.

Cause: the AppSync \`request_template\` sent a non-standard event shape:

\`\`\`json
{\"field\": \"listActionLogs\", \"typeName\": \"Query\", ...}
\`\`\`

But the Lambda dispatcher in every \`modules/*/src/handler.py\` reads:

\`\`\`python
field = event.get(\"info\", {}).get(\"fieldName\", \"\")
\`\`\`

So every field looked up against \`FIELD_HANDLERS[\"\"]\` → no match → \`UnknownFieldError\` → AppSync set \`data.<field> = null\` → GraphQL's non-null schema check reported the visible \"Cannot return null for non-nullable type\" error.

This affected the #34 resolvers too. Smoke script never caught it because the assertions only checked HTTP 200, not response data shape (most fields returned empty results from a fresh tenant, indistinguishable from \"silently failing\").

## Fix

One change to \`fluxion-backend/terraform/modules/api/resolvers.tf\`. Replace:

\`\`\`vtl
\"payload\": {
  \"field\": \"...\",
  \"typeName\": \"...\",
  ...
}
\`\`\`

with the AWS-standard direct-resolver shape:

\`\`\`vtl
\"payload\": {
  \"info\": {\"fieldName\": \"...\", \"parentTypeName\": \"...\"},
  ...
}
\`\`\`

Matches what aws-lambda-powertools and AppSync direct-resolver docs document, and what the dispatchers already read.

## Verified

- \`terraform validate\` passes
- Direct \`aws lambda invoke\` with the new payload shape returns correct results (verified via P4 smoke setup)

## After merge

Promote develop → master → Deploy auto-triggers → AppSync resolver template updated → all 16 (now 22) GraphQL fields actually work end-to-end.