### PR TITLE
Promote develop → master: AppSync request_template fix (#104)

### DIFF
--- a/fluxion-backend/terraform/modules/api/resolvers.tf
+++ b/fluxion-backend/terraform/modules/api/resolvers.tf
@@ -9,7 +9,12 @@ resource "aws_appsync_resolver" "unit" {
   field       = each.value.field_name
   data_source = aws_appsync_datasource.lambda[each.value.resolver].name
 
-  # Classic AppSync Lambda invocation template.
+  # Classic AppSync Lambda invocation template — uses the AWS standard
+  # event shape so Lambda dispatchers can read event["info"]["fieldName"].
+  # The original (field/typeName) shape was non-standard and the Lambda
+  # dispatchers in fluxion-backend/modules/*/src/handler.py don't read it,
+  # so every resolver silently raised UnknownFieldError. Replaced with
+  # info{} to match `aws_lambda_powertools` / standard direct-resolver shape.
   # $util.* and $ctx.* are VTL — Terraform leaves them alone because they
   # don't use the ${...} interpolation syntax.
   request_template = <<-EOT
@@ -17,8 +22,10 @@ resource "aws_appsync_resolver" "unit" {
       "version": "2018-05-29",
       "operation": "Invoke",
       "payload": {
-        "field": "${each.value.field_name}",
-        "typeName": "${each.value.type_name}",
+        "info": {
+          "fieldName": "${each.value.field_name}",
+          "parentTypeName": "${each.value.type_name}"
+        },
         "arguments": $util.toJson($ctx.args),
         "identity": $util.toJson($ctx.identity),
         "source": $util.toJson($ctx.source),


### PR DESCRIPTION
Promotes the AppSync request_template fix to master so all 22 GraphQL fields actually work end-to-end. Without this, every resolver silently failed with UnknownFieldError.

## What lands on master

- `fluxion-backend/terraform/modules/api/resolvers.tf` — 10-line template change

## Expected Deploy flow

Backend path filter matches (TF module change). Standard chain:
1. lint ✓
2. tf-backend-ecr-bootstrap ✓ (no-op)
3. docker-push-backend ✓ (cache hits, no source changes)
4. tf-backend full apply ✓ — only AppSync resolver template updates