### PR TITLE
[#35]: add workflow_dispatch trigger to Deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,11 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  # Manual trigger — useful when a merge-commit push doesn't change any
+  # files dorny/paths-filter detects (e.g. promotion PRs that only carry
+  # changes already on master). Run via:
+  #   gh workflow run deploy.yml --ref master
+  workflow_dispatch: {}
 
 concurrency:
   # Serialize main-branch applies; PR plan runs keyed by PR so they don't block each other.


### PR DESCRIPTION
## Why

dorny/paths-filter on merge-commit pushes doesn't always detect changes that ARE in the merge. Saw this on:
- PR #103 promotion (oidc.tf change in merge): all jobs skipped
- PR #105 promotion (resolvers.tf template fix): all jobs skipped

Both runs reported "success" but actually did nothing — masking real changes that should have deployed.

## Fix

Add `workflow_dispatch:` so:
1. THIS PR's promotion will trigger a real backend pipeline (deploy.yml is in the backend path filter).
2. Future stuck pipelines can be unblocked with:
   ```
   gh workflow run deploy.yml --ref master
   ```

5 lines added. No other changes.