### PR TITLE
Promote develop → master: workflow_dispatch + previously-stuck request_template fix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,11 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  # Manual trigger — useful when a merge-commit push doesn't change any
+  # files dorny/paths-filter detects (e.g. promotion PRs that only carry
+  # changes already on master). Run via:
+  #   gh workflow run deploy.yml --ref master
+  workflow_dispatch: {}
 
 concurrency:
   # Serialize main-branch applies; PR plan runs keyed by PR so they don't block each other.


### PR DESCRIPTION
Carries 2 commits to master:
- `2c1e6b8` [#35] add workflow_dispatch to Deploy
- `76e5c8e` [#35] fix AppSync request_template to send info.fieldName

The previous promotion (#105) merged the template fix but Deploy's paths-filter didn't detect the change in the merge commit, so it didn't actually apply. This promotion includes a deploy.yml change (workflow_dispatch addition) which IS in the path filter, so the merge will trigger a real backend pipeline that publishes BOTH changes.