### PR TITLE
Promote develop → master: paths-filter dispatch fix (#108) + accumulated #35 follow-ups

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,9 +30,13 @@ jobs:
     name: detect changes + enumerate modules
     runs-on: ubuntu-latest
     outputs:
-      backend: ${{ steps.filter.outputs.backend }}
-      oem: ${{ steps.filter.outputs.oem }}
-      frontend: ${{ steps.filter.outputs.frontend }}
+      # Force every domain to "true" on workflow_dispatch — dorny/paths-filter
+      # has no diff base on a manual trigger and would return all-false,
+      # making manual triggers useless. Same fallback for merge-commit pushes
+      # where paths-filter intermittently misses changes (seen on PRs #103/#105/#107).
+      backend: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'push') && 'true' || steps.filter.outputs.backend }}
+      oem: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'push') && 'true' || steps.filter.outputs.oem }}
+      frontend: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'push') && 'true' || steps.filter.outputs.frontend }}
       backend_modules: ${{ steps.list-modules.outputs.backend }}
       oem_modules: ${{ steps.list-modules.outputs.oem }}
     steps:


### PR DESCRIPTION
Final round of #35 fixes. Carries:
- #108 paths-filter bypass on push/workflow_dispatch
- #106 workflow_dispatch trigger
- #104 AppSync request_template fix

After merge, push event will trigger Deploy and ALL backend jobs WILL run (no more paths-filter false-negatives), publishing the AppSync template change live.