### PR TITLE
Promote develop → master: Cognito custom:tenant_id (#110)

### DIFF
--- a/fluxion-backend/scripts/provision-dev-admin.sh
+++ b/fluxion-backend/scripts/provision-dev-admin.sh
@@ -108,10 +108,16 @@ if [[ "$USER_EXISTS" == "NOT_FOUND" ]]; then
     --user-attributes \
       Name=email,Value="$DEV_ADMIN_EMAIL" \
       Name=email_verified,Value=true \
+      Name=custom:tenant_id,Value="1" \
     >/dev/null
   log "Cognito user created."
 else
-  log "Cognito user already exists — skipping create."
+  log "Cognito user already exists — ensuring custom:tenant_id attribute is set."
+  aws cognito-idp admin-update-user-attributes \
+    --user-pool-id "$USER_POOL_ID" \
+    --username "$DEV_ADMIN_EMAIL" \
+    --user-attributes Name=custom:tenant_id,Value="1" \
+    >/dev/null
 fi
 
 # ── Step 4: Set permanent password ────────────────────────────────────────────

--- a/fluxion-backend/terraform/modules/auth/main.tf
+++ b/fluxion-backend/terraform/modules/auth/main.tf
@@ -31,6 +31,20 @@ resource "aws_cognito_user_pool" "main" {
     }
   }
 
+  # Tenant scope claim — Lambda resolvers read event.identity.claims["custom:tenant_id"]
+  # to scope DB queries via accesscontrol.tenants lookup. Required by build_context_from
+  # in modules/_template/src/auth.py (mirrored in every resolver's auth.py).
+  schema {
+    name                = "tenant_id"
+    attribute_data_type = "String"
+    mutable             = true
+    required            = false
+    string_attribute_constraints {
+      min_length = 1
+      max_length = 32
+    }
+  }
+
   lifecycle {
     prevent_destroy = true
   }


### PR DESCRIPTION
Promotes #110 (Cognito tenant_id attr) to master so the user pool gets the new attribute via Deploy. After this lands, must run provision-dev-admin.sh with admin creds to set tenant_id=1 on existing dev-admin.